### PR TITLE
AutoDiffCostFunction 변경

### DIFF
--- a/include/CLieAlgebra.h
+++ b/include/CLieAlgebra.h
@@ -4,6 +4,8 @@
 
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include "ceres/ceres.h"
+#include "ceres/jet.h"
 #include <math.h>
 #include <random>
 #include <iostream>
@@ -14,20 +16,116 @@ class LieAlgebraError: public std::exception{
             return "LieAlgebra error";
         }
 };
-struct so3{
-    Eigen::Vector3d w;
+// struct so3{
+//     Eigen::Vector3d w;
+// };
+// struct se3{
+//     Eigen::Vector3d rot;
+//     Eigen::Vector3d trans;
+//     se3(Eigen::Vector3d _rot, Eigen::Vector3d _trans) : rot(_rot), trans(_trans){};
+//     se3() : rot(Eigen::Vector3d::Zero()), trans(Eigen::Vector3d::Zero()){};
+//     std::string to_string() const {
+//         std::string message = std::to_string(rot(0))+"\t"+std::to_string(rot(1))+"\t"+std::to_string(rot(2))+
+//         "\t"+std::to_string(trans(0))+"\t"+std::to_string(trans(1))+"\t"+std::to_string(trans(2));
+//         return message;
+//     }
+//     se3 from_string(const std::string& str) {
+//         se3 result;
+//         std::stringstream ss(str);
+//         std::string segment;
+//         std::vector<double> values;
+
+//         for (int i=0; i<6; i++) {
+//             if (std::getline(ss, segment, '\t')) {
+//                 try {
+//                     values.push_back(std::stod(segment));
+//                 }
+//                 catch (const std::invalid_argument& e) {
+//                     throw std::runtime_error("from_string: Invalid number format in segment '" + segment + "': " + e.what());
+//                 }
+//                 catch (const std::out_of_range& e) {
+//                     throw std::runtime_error("from_string: Number out of range in segment '" + segment + "': " + e.what());
+//                 }
+//             }
+//             else {
+//                 throw std::runtime_error("from_string: Not enough segments in string. Expected 6, got " + std::to_string(i));
+//             }
+//         }
+
+//         if (values.size() != 6) {
+//             throw std::runtime_error("from_string: Incorrect number of values parsed. Expected 6, got " + std::to_string(values.size()));
+//         }
+
+//         result.rot(0) = values[0];
+//         result.rot(1) = values[1];
+//         result.rot(2) = values[2];
+//         result.trans(0) = values[3];
+//         result.trans(1) = values[4];
+//         result.trans(2) = values[5];
+
+//         return result;
+//     }
+// };
+
+template <typename T>
+struct so3_T{
+    Eigen::Matrix<T, 3, 1> w;
 };
-struct se3{
-    Eigen::Vector3d rot;
-    Eigen::Vector3d trans;
-    se3(Eigen::Vector3d _rot, Eigen::Vector3d _trans) : rot(_rot), trans(_trans){};
-    se3() : rot(Eigen::Vector3d::Zero()), trans(Eigen::Vector3d::Zero()){};
-    std::string to_string(){
+
+template <typename T>
+struct se3_T{
+    Eigen::Matrix<T, 3, 1> rot;
+    Eigen::Matrix<T, 3, 1> trans;
+    se3_T(const Eigen::Matrix<T, 3, 1>& _rot, const Eigen::Matrix<T, 3, 1>& _trans) : rot(_rot), trans(_trans){};
+    se3_T() : rot(Eigen::Matrix<T, 3, 1>::Zero()), trans(Eigen::Matrix<T, 3, 1>::Zero()){};
+    std::string to_string() const {
         std::string message = std::to_string(rot(0))+"\t"+std::to_string(rot(1))+"\t"+std::to_string(rot(2))+
         "\t"+std::to_string(trans(0))+"\t"+std::to_string(trans(1))+"\t"+std::to_string(trans(2));
         return message;
     }
+    se3_T from_string(const std::string& str) {
+        se3_T result;
+        std::stringstream ss(str);
+        std::string segment;
+        std::vector<double> values;
+
+        for (int i=0; i<6; i++) {
+            if (std::getline(ss, segment, '\t')) {
+                try {
+                    values.push_back(std::stod(segment));
+                }
+                catch (const std::invalid_argument& e) {
+                    throw std::runtime_error("from_string: Invalid number format in segment '" + segment + "': " + e.what());
+                }
+                catch (const std::out_of_range& e) {
+                    throw std::runtime_error("from_string: Number out of range in segment '" + segment + "': " + e.what());
+                }
+            }
+            else {
+                throw std::runtime_error("from_string: Not enough segments in string. Expected 6, got " + std::to_string(i));
+            }
+        }
+
+        if (values.size() != 6) {
+            throw std::runtime_error("from_string: Incorrect number of values parsed. Expected 6, got " + std::to_string(values.size()));
+        }
+
+        result.rot(0) = values[0];
+        result.rot(1) = values[1];
+        result.rot(2) = values[2];
+        result.trans(0) = values[3];
+        result.trans(1) = values[4];
+        result.trans(2) = values[5];
+
+        return result;
+    }
 };
+
+typedef so3_T<double> so3;
+
+typedef se3_T<double> se3;
+
+
 
 using namespace std;
 
@@ -35,10 +133,10 @@ class LieAlgebra{
     public:
         // transformation between matrix form and screw vector fom
         static Eigen::Matrix3d randomE(Eigen::Vector3d standard, double delta);
-        static Eigen::Vector3d to_so3(const Eigen::Matrix3d &R);
-        static Eigen::Vector3d normalize_so3(const Eigen::Vector3d &_w);
-        static Eigen::Matrix3d to_SO3(const Eigen::Vector3d &_w);
-        static Eigen::Matrix3d to_E(se3 se3);
+        // static Eigen::Vector3d to_so3(const Eigen::Matrix3d &R);
+        // static Eigen::Vector3d normalize_so3(const Eigen::Vector3d &_w);
+        // static Eigen::Matrix3d to_SO3(const Eigen::Vector3d &_w);
+        // static Eigen::Matrix3d to_E(se3 se3);
         static Eigen::Matrix4d to_SE3(se3 se3);
         static se3 to_se3(const Eigen::Matrix4d &T);
         static se3 to_se3(const Eigen::Matrix3d &E);
@@ -46,10 +144,92 @@ class LieAlgebra{
         static se3 solveAXXB(const vector<pair<se3, se3>> &ABs);
 
 
+        //template ftn
+        template<typename T>
+        static Eigen::Matrix<T, 3, 1> to_so3(const Eigen::Matrix<T, 3, 3> &R) {
+            T trace_R = R.trace();
+            if(trace_R > T(3.) || trace_R < T(-3.)) {
+                cout<< R*R.transpose()<<endl;
+                throw LieAlgebraError();
+            }
+
+            T theta = ceres::acos((trace_R - T(1.0)) / T(2.0));
+
+            if (ceres::abs(theta) < T(1e-12)) return Eigen::Matrix<T, 3, 1>::Zero();
+
+            Eigen::Matrix<T, 3, 3> skew_m = (theta / (T(2.) * ceres::sin(theta))) * (R - R.transpose()); // ceres::sin 사용
+            Eigen::Matrix<T, 3, 1> skew_v(skew_m(2, 1), skew_m(0, 2), skew_m(1, 0));
+            // std::cout << skew_v << std::endl;
+            return skew_v;
+        }
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 1> normalize_so3(const Eigen::Matrix<T, 3, 1> &_w) {
+            Eigen::Matrix<T, 3, 1> w = _w;
+            T norm_w = w.norm();
+            T scale = norm_w / T(M_PI);
+
+            if (scale > T(1)) {
+                int share;
+
+                if constexpr (std::is_same_v<T, double>) {
+                    share = static_cast<int>(ceres::floor(scale));
+                }
+                else {
+                    share = static_cast<int>(ceres::floor(scale).a);
+                }
+
+                if (share % 2 == 0) {
+                    w = w / scale * (scale - T(static_cast<double>(share)));
+                }
+                else {
+                    w = w / scale * (scale - T(static_cast<double>(share)) - T(1));
+                }
+            }
+            return w;
+        }
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> to_SO3(const Eigen::Matrix<T, 3, 1> & _w) {
+            Eigen::Matrix<T, 3, 1> w = normalize_so3(_w);
+            T theta = w.norm();
+
+            if (ceres::abs(theta) < T(1e-12))
+                return Eigen::Matrix<T, 3, 3>::Identity();
+
+            Eigen::Matrix<T, 3, 3> w_hat = skew_symmetric_matrix(w);
+            Eigen::Matrix<T, 3, 3> mat = Eigen::Matrix<T, 3, 3>::Identity() + (ceres::sin(theta) / theta) * w_hat + ((T(1.0) - ceres::cos(theta)) / (theta * theta)) * (w_hat * w_hat);
+
+            return mat;
+        }
+
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> to_E(se3_T<T> se3_val) {
+            Eigen::Matrix<T, 3, 3> Rot, E;
+            Rot = LieAlgebra::to_SO3(se3_val.rot);
+            E.col(0)= Rot.col(0);
+            E.col(1)= Rot.col(1);
+            E.col(2)= se3_val.trans;
+
+            return E;
+        }
+
+
 
     private:
         static Eigen::Vector3d random_vector(double min, double max);
         static Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v);
+
+        //template ftn
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> skew_symmetric_matrix(const Eigen::Matrix<T, 3, 1> &v) {
+            Eigen::Matrix<T, 3, 3> skew;
+            skew << T(0.), -v(2), v(1),
+                    v(2), T(0.), -v(0),
+                    -v(1), v(0), T(0.);
+            return skew;
+        }
 
 };
 

--- a/include/CMomentsTracker.h
+++ b/include/CMomentsTracker.h
@@ -7,15 +7,29 @@
 #include "math.h"
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include "ceres/ceres.h"
+#include "ceres/jet.h"
 #include "utils.h"
 using namespace std;
 
 
-class MomentsTrackerError: public std::exception{
-    public:
-        const char* what(){
-            return "Value exceed the range";
-        }
+// class MomentsTrackerError: public std::exception{
+//     public:
+//         const char* what(){
+//             return "Value exceed the range";
+//         }
+// };
+
+class MomentsTrackerError : public std::exception {
+private:
+    std::string message;
+
+public:
+    explicit MomentsTrackerError(const std::string& msg)
+        : message(msg) {}
+    const char* what() const noexcept override {
+        return message.c_str();
+    }
 };
 
 class MomentsTracker
@@ -27,13 +41,84 @@ private:
     vector<vector<double>> moment_buffer;
     void init();
     double _M_2i2j(int i, int j);
-    double C0n(int n, vector<double> ds);
-    double C1n(int n, vector<double> ds);
-    double nCr(int i, int j);
+    // double C0n(int n, vector<double> ds);
+    // double C1n(int n, vector<double> ds);
+    // double nCr(int i, int j);
     double I_2i2j(int i, int j);
     double M_2i2j(int i, int j);
-    double M_2i2j(int i, int j, double a, double b);
-    array<double ,3> intSn(int n,double a, double b, double tx, double ty,double alpha);
+    // double M_2i2j(int i, int j, double a, double b);
+    // array<double ,3> intSn(int n,double a, double b, double tx, double ty,double alpha);
+
+
+    //template ftn
+    template<typename T>
+    T C0n(int n, const std::vector<T>& ds) {
+        T result = T(0);
+        int n_d = max_dim;
+        for (int i = std::max(0, n - n_d); i < std::min(n, n_d) + 1; i++) {
+            result += T(2 * i + 1) * ds[i] * ds[n - i];
+        }
+        return result;
+    }
+
+    template<typename T>
+    T C1n(int n, const std::vector<T>& ds) {
+        T result = T(0);
+        int n_d = max_dim;
+        for (int i = std::max(0, n - n_d * 2); i < std::min(n, n_d) + 1; i++) {
+            T temp = T(0);
+            for (int j = std::max(0, n - i - n_d); j < std::min(n - i, n_d) + 1; j++) {
+                temp += ds[j] * ds[n - i - j];
+            }
+            result += T(2 * i + 1) * ds[i] * temp;
+        }
+        return result;
+    }
+
+    template<typename T>
+    T nCr(int n, int r) {
+        if (n > comb_max || n < r) throw MomentsTrackerError("nCr error!!");
+        return T(static_cast<double>(comb_buffer[n][r]));  
+    }
+
+    template<typename T>
+    T M_2i2j(int i, int j, T a, T b) {
+        T base_M_val = T(MomentsTracker::M_2i2j(i, j));
+        return base_M_val * ceres::pow(a, T(2 * i)) * ceres::pow(b, T(2 * j)); 
+    }
+
+    template<typename T>
+    array<T, 3> intSn(int n, T a, T b, T tx, T ty, T alpha) {
+        T tx_s = ceres::cos(alpha) * tx + ceres::sin(alpha) * ty;
+        T ty_s = -ceres::sin(alpha) * tx + ceres::cos(alpha) * ty;
+        T s0 = T(0), sx = T(0), sy = T(0);
+        std::array<T, 3> results;
+
+        for (int i = 0; i < n + 1; i++) {
+            for (int j = 0; j < n - i + 1; j++) {
+                T M = M_2i2j(i, j, a, b);
+                T m_0 = T(0);
+                T m_x = T(0);
+                T m_y = T(0);
+                for (int k = i; k < n - j + 1; k++) {
+                    m_0 += nCr<double>(n, k) * nCr<double>(2 * k, 2 * i) * nCr<double>(2 * (n - k), 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i))) * ceres::pow(ty_s, T(2 * (n - j - k)));
+                    m_x += nCr<double>(n, k) * nCr<double>(2 * k + 1, 2 * i) * nCr<double>(2 * (n - k), 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i) + 1)) * ceres::pow(ty_s, T(2 * (n - j - k)));
+                    m_y += nCr<double>(n, k) * nCr<double>(2 * k, 2 * i) * nCr<double>(2 * (n - k) + 1, 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i))) * ceres::pow(ty_s, T(2 * (n - j - k) + 1));
+                }
+                s0 += m_0 * M;
+                sx += m_x * M;
+                sy += m_y * M;
+            }
+        }
+        results[0] = s0;
+        results[1] = ceres::cos(alpha) * sx - ceres::sin(alpha) * sy;
+        results[2] = ceres::sin(alpha) * sx + ceres::cos(alpha) * sy;
+        return results;
+    }
+
     
 
 public:
@@ -43,11 +128,108 @@ public:
 
 
     Point ne2dp(Eigen::Matrix3d Q, vector<double> ds);
+
     Point wc2dp_Numerical(Eigen::Matrix3d Cw,Eigen::Matrix3d H, vector<double> ds,int total_iter=1600);
     Point ne2dp_Numerical(Eigen::Matrix3d Q, vector<double> ds);
+    
     Point project(double wx, double wy, double r,Params intrinsic, Eigen::Matrix3d E, int mode);
-    array<double, 5> ellipse2array(Eigen::Matrix3d Q);
+
     Point distort_Point(Point pn, vector<double> ds);
+
+
+    //template ftn
+    template<typename T>
+    Point_T<T> ne2dp(Eigen::Matrix<T, 3, 3> Q, const std::vector<T>& ds) {
+        /*
+        input: ellips in normal plane and distortion parameter
+        output: centor point of region of distorted ellipse
+        */
+
+        std::array<T, 5> ellipse = ellipse2array(Q);
+
+        T a, b, tx, ty, alpha;
+        tx = ellipse[0];
+        ty = ellipse[1];
+        a = ellipse[2];
+        b = ellipse[3];
+        alpha = ellipse[4];
+        T A_d = T(0);
+        T x_d = T(0);
+        T y_d = T(0);
+
+        for (int n = 0; n < 3 * max_dim + 1; n++) {
+            T c_0n = C0n(n, ds);
+            T c_1n = C1n(n, ds); 
+            std::array<T, 3> all_Sn = intSn(n, a, b, tx, ty, alpha);
+            A_d += c_0n * all_Sn[0];
+            x_d += c_1n * all_Sn[1];
+            y_d += c_1n * all_Sn[2];
+        }
+
+        x_d = x_d / A_d;
+        y_d = y_d / A_d;
+        return Point_T<T>(x_d, y_d);
+    }
+
+    template<typename T>
+    Point_T<T> project(T wx, T wy, T r, Params_T<T> intrinsic, Eigen::Matrix<T, 3, 3> E, int mode=0) {
+        Eigen::Matrix<T, 3, 3> Cw;
+        Cw <<   T(1.0), T(0.0), -wx,
+                T(0.0), T(1.0), -wy,
+                -wx, -wy, ceres::pow(wx,2) + ceres::pow(wy,2) - ceres::pow(r,2); // ceres::pow 사용
+
+        std::vector<T> ds = {T(1), intrinsic.d[0], intrinsic.d[1], intrinsic.d[2], intrinsic.d[3]};
+
+        Point_T<T> dp(T(0),T(0));
+
+        if(mode ==0){
+            Eigen::Matrix<T, 3, 3> E_inv=  E.inverse();
+            Eigen::Matrix<T, 3, 3> Qn = E_inv.transpose()*Cw*E_inv;
+            dp = ne2dp(Qn,ds);
+        }
+        else{
+            throw MomentsTrackerError("project error: only mode=0");
+        }
+
+        T u_e = dp.x*intrinsic.fx+dp.y*intrinsic.skew+intrinsic.cx; 
+        T v_e = dp.y*intrinsic.fy+intrinsic.cy;
+
+        return Point_T<T>(u_e, v_e);
+    }
+
+    template<typename T> 
+    array<T, 5> ellipse2array(Eigen::Matrix<T, 3, 3> Q) {
+        T a = Q(0, 0), b = Q(0, 1), c = Q(1, 1), d = Q(0, 2), e = Q(1, 2), f = Q(2, 2);
+        T x, y, m0, m1, v0, v1;
+        T det_Q = Q.determinant(); 
+        T det_Q33 = a * c - b * b; 
+        T s = a + c;
+        x = (-c * d + b * e) / det_Q33;
+        y = (b * d - a * e) / det_Q33;
+
+        T k = -det_Q / det_Q33;
+        T root = ceres::sqrt(ceres::pow(a - c, T(2)) + T(4) * ceres::pow(b, T(2)));
+        T lamda0 = (s - root) / T(2);
+        T lamda1 = (s + root) / T(2);
+        m0 = ceres::sqrt(k / lamda0);
+        m1 = ceres::sqrt(k / lamda1);
+        
+        if (ceres::abs(b) < T(1e-12)) {
+            v0 = T(0);
+            v1 = T(1);
+        } else {
+            v0 = ((c - a) + root) / T(2);
+            v1 = -b;
+        }
+        T alpha = ceres::atan2(v1, v0);
+
+        array<T, 5> result = {x, y, m0, m1, alpha};
+        return result;
+    }
+
+
+
+
 };
 
 

--- a/include/CTargetDetector.h
+++ b/include/CTargetDetector.h
@@ -30,7 +30,7 @@ class WrongTypeException: public std::exception{
 class TargetDetector{
     public:
         TargetDetector(int n_x, int n_y, bool draw = true);
-        pair<bool,vector<Shape>>detect(cv::Mat& img, string type);
+        pair<bool,vector<Shape>>detect(cv::Mat& img, string type, bool key_input=true); //modified: key_input
         static cv::Mat preprocessing(cv::Mat img, string detection_mode);
         static cv::Mat translation_blur(const cv::Mat &img, double trans);
         static cv::Mat rotation_blur(const cv::Mat &img, double dtheta);
@@ -57,7 +57,7 @@ class TargetDetector{
 
         void update_autocorrelation(cv::Mat &src, vector<Shape>& control_shapes);
 
-        void visualize_result(cv::Mat& img_output, pair<bool,vector<Shape>> &result);
+        void visualize_result(cv::Mat& img_output, pair<bool,vector<Shape>> &result, bool key_input = true); //modified: key_input
 
         //for exp
         bool detect_circles_banilar(cv::Mat& img, cv::Mat& img_output,vector<Shape>&target, bool debug);

--- a/include/mono.hpp
+++ b/include/mono.hpp
@@ -56,8 +56,8 @@ void MonoCalibration::mono_calibration(YAML::Node node){
     if( option_node["save_pose"]) save_pose = option_node["save_pose"].as<bool>();
     bool save_rpe= false;
     if(option_node["save_rpe"]) save_rpe= option_node["save_rpe"].as<bool>();
-    bool evaluation= false;
-    if(option_node["evaluation"]) evaluation= option_node["evaluation"].as<bool>();
+    bool save_jacob= false;
+    if(option_node["save_jacob"]) save_jacob= option_node["save_jacob"].as<bool>();
     bool fix_intrinsic= false;
     if(option_node["fix_intrinsic"])fix_intrinsic= option_node["fix_intrinsic"].as<bool>();
 
@@ -70,7 +70,7 @@ void MonoCalibration::mono_calibration(YAML::Node node){
         string path = split<string>(s,'/').back();
         // if (path.find(type) == string::npos) continue;
         if(check_img_path(path)){
-            imgs.push_back(s);
+                imgs.push_back(s);
         }
     }
     sort(imgs.begin(),imgs.end());
@@ -80,13 +80,13 @@ void MonoCalibration::mono_calibration(YAML::Node node){
         throw LackOfImageError();
     }
 
-    string results_path = img_dir+"calibration_results/";
+    string results_path = img_dir+"detection_results/";
     mkdir(results_path);
 
     TargetDetector detector(n_x, n_y,visualize);
     pair<bool,vector<Shape>> result;
     int count=0;
-    Calibrator calibrator = Calibrator(n_x,n_y,n_d,r,distance,max_scene,results_path);
+    Calibrator calibrator = Calibrator(n_x,n_y,n_d,r,distance,max_scene,img_dir);
 
     // vector<int> success_img_list;
     vector<int> fail_img_list;
@@ -97,7 +97,6 @@ void MonoCalibration::mono_calibration(YAML::Node node){
     const int LEN = 20;
     const char bar = '=';
     const char blank = ' ';
-    bool need_init = true;
     for(int i=0; i<imgs.size();i++){
         if(calibrator.get_num_scene()==max_scene) break;
         print_process(i+1,max_scene,"Detecting image: ");
@@ -106,13 +105,11 @@ void MonoCalibration::mono_calibration(YAML::Node node){
         cv::Mat bgr_img, gray_img,hsv_img;
         bgr_img = cv::imread(path, cv::IMREAD_COLOR);
         gray_img = TargetDetector::preprocessing(bgr_img,detection_mode);
+                
         if(gray_img.rows == 0){
             throw exception();
         }
-        if(need_init) {
-            calibrator.set_image_size(gray_img.cols, gray_img.rows);
-            need_init=false;
-        }
+
         if(visualize) cout<<"start detect: "<<path<<endl;
         result = detector.detect(gray_img, type);
         detector.save_result(results_path+std::to_string(i)+".png");
@@ -148,12 +145,12 @@ void MonoCalibration::mono_calibration(YAML::Node node){
             cout<<table <<endl;
             calibrator.update_Es(final_params,0);
         }
-        else final_params=calibrator.calibrate(0,evaluation);
+        else final_params=calibrator.calibrate(0,save_jacob);
         if(save_pose) calibrator.save_extrinsic(img_dir+"est_pose_c0.txt");
         if(save_rpe) calibrator.visualize_rep(img_dir+"rpe_c0.txt",final_params,0);
     }
     else{
-        final_params=calibrator.calibrate(2,evaluation);
+        final_params=calibrator.calibrate(2,save_jacob);
         if(save_pose) calibrator.save_extrinsic(img_dir+"est_pose_s.txt");
         if(save_rpe) calibrator.visualize_rep(img_dir+"rpe_s.txt",final_params,2);
     }

--- a/include/stereo.hpp
+++ b/include/stereo.hpp
@@ -69,8 +69,8 @@ vector<pair<se3,bool>> StereoCalibration::calExtrinsic(YAML::Node args, int came
     if( option_node["save_pose"]) save_pose = option_node["save_pose"].as<bool>();
     bool save_rpe= false;
     if(option_node["save_rpe"]) save_rpe= option_node["save_rpe"].as<bool>();
-    bool evaluation= false;
-    if(option_node["evaluation"]) evaluation= option_node["evaluation"].as<bool>();
+    bool save_jacob= false;
+    if(option_node["save_jacob"]) save_jacob= option_node["save_jacob"].as<bool>();
 
 
     vector<string> imgs;
@@ -88,11 +88,11 @@ vector<pair<se3,bool>> StereoCalibration::calExtrinsic(YAML::Node args, int came
         std::cout<<LackOfImageError().what()<<std::endl;
         throw LackOfImageError();
     }
-    string results_path = img_dir+"calibration_results/";
+    string results_path = img_dir+"detection_results/";
     mkdir(results_path);
 
     TargetDetector detector(n_x, n_y,visualize);
-    Calibrator calibrator = Calibrator(n_x,n_y,n_d,r,distance,max_scene,results_path);
+    Calibrator calibrator = Calibrator(n_x,n_y,n_d,r,distance,max_scene,img_dir);
     vector<bool> valid_scene; 
 
     struct timeval  tv;
@@ -102,7 +102,7 @@ vector<pair<se3,bool>> StereoCalibration::calExtrinsic(YAML::Node args, int came
     const int LEN = 20;
     const char bar = '=';
     const char blank = ' ';
-    bool need_init = true;
+
     vector<int> fail_img_list;
     for(int i=0; i<imgs.size();i++){
         if(i==max_scene) break;
@@ -111,10 +111,6 @@ vector<pair<se3,bool>> StereoCalibration::calExtrinsic(YAML::Node args, int came
         bgr_img = cv::imread(path, cv::IMREAD_COLOR);
         gray_img = TargetDetector::preprocessing(bgr_img,detection_mode);
         if(gray_img.rows == 0) throw exception();
-        if(need_init) {
-            calibrator.set_image_size(gray_img.rows, gray_img.cols);
-            need_init=false;
-        }
         if(visualize) cout<<"start detect: "<<path<<endl;
         pair<bool,vector<Shape>> result = detector.detect(gray_img, type);
         detector.save_result(results_path+std::to_string(i)+".png");
@@ -143,7 +139,7 @@ vector<pair<se3,bool>> StereoCalibration::calExtrinsic(YAML::Node args, int came
     // 0: moment, 1: conic, 2: point, 4: numerical, 5: iterative
     int mode = 0;
     if(type != "circle") mode=2;
-    if(cal_intrinsic) calibrator.calibrate(mode,evaluation);
+    if(cal_intrinsic) calibrator.calibrate(mode,save_jacob);
     else calibrator.update_Es(Params(camera_node),mode);
 
     if(save_pose) calibrator.save_extrinsic();

--- a/src/lib_calib/CLieAlgebra.cpp
+++ b/src/lib_calib/CLieAlgebra.cpp
@@ -9,63 +9,65 @@ Eigen::Matrix3d LieAlgebra::skew_symmetric_matrix(const Eigen::Vector3d &v)
     return skew;
 }
 
-Eigen::Vector3d LieAlgebra::to_so3(const Eigen::Matrix3d &R)
-{
-    double trace_R = R.trace();
-    if(trace_R >3 || trace_R <-3) {
-        cout<< R*R.transpose()<<endl;
-        throw LieAlgebraError();
-    }
-    double theta = acos((trace_R - double(1.0)) / double(2.0));
 
-    if (theta == double(0.))
-        return Eigen::Vector3d::Zero();
+// Eigen::Vector3d LieAlgebra::to_so3(const Eigen::Matrix3d &R)
+// {
+//     double trace_R = R.trace();
+//     if(trace_R >3 || trace_R <-3) {
+//         cout<< R*R.transpose()<<endl;
+//         throw LieAlgebraError();
+//     }
+//     double theta = acos((trace_R - double(1.0)) / double(2.0));
 
-    Eigen::Matrix3d skew_m = (theta / (double(2.) * sin(theta))) * (R - R.transpose());
-    Eigen::Vector3d skew_v(skew_m(2, 1), skew_m(0, 2), skew_m(1, 0));
-    return skew_v;
-}
+//     if (theta == double(0.))
+//         return Eigen::Vector3d::Zero();
 
-Eigen::Vector3d LieAlgebra::normalize_so3(const Eigen::Vector3d &_w)
-{
-    Eigen::Vector3d w = _w;
-    double scale = w.norm()/M_PI;
-    if(scale>1){
-        int share = int(scale);
-        if(share%2 ==0){
-            w = w/scale*(scale-share);
-        }
-        else{
-            w = w/scale*(scale-share-1);
-        }
-    }
-    return w;
-}
+//     Eigen::Matrix3d skew_m = (theta / (double(2.) * sin(theta))) * (R - R.transpose());
+//     Eigen::Vector3d skew_v(skew_m(2, 1), skew_m(0, 2), skew_m(1, 0));
+//     return skew_v;
+// }
 
-Eigen::Matrix3d LieAlgebra::to_SO3(const Eigen::Vector3d & _w)
-{
-    Eigen::Vector3d w = normalize_so3(_w);
-    // Eigen::Vector3d w = _w;
-    double theta = w.norm();
-    if (theta == double(0))
-        return Eigen::Matrix3d::Identity();
 
-    Eigen::Matrix3d w_hat = skew_symmetric_matrix(w);
-    Eigen::Matrix3d mat = Eigen::Matrix3d::Identity() + (sin(theta) / theta) * w_hat + ((1.0 - cos(theta)) / (theta * theta)) * (w_hat * w_hat);
 
-    return mat;
-}
+// Eigen::Vector3d LieAlgebra::normalize_so3(const Eigen::Vector3d &_w)
+// {
+//     Eigen::Vector3d w = _w;
+//     double scale = w.norm()/M_PI;
+//     if(scale>1){
+//         int share = int(scale);
+//         if(share%2 ==0){
+//             w = w/scale*(scale-share);
+//         }
+//         else{
+//             w = w/scale*(scale-share-1);
+//         }
+//     }
+//     return w;
+// }
 
-Eigen::Matrix3d LieAlgebra::to_E(se3 se3){
+// Eigen::Matrix3d LieAlgebra::to_SO3(const Eigen::Vector3d & _w)
+// {
+//     Eigen::Vector3d w = normalize_so3(_w);
+//     // Eigen::Vector3d w = _w;
+//     double theta = w.norm();
+//     if (theta == double(0))
+//         return Eigen::Matrix3d::Identity();
+
+//     Eigen::Matrix3d w_hat = skew_symmetric_matrix(w);
+//     Eigen::Matrix3d mat = Eigen::Matrix3d::Identity() + (sin(theta) / theta) * w_hat + ((1.0 - cos(theta)) / (theta * theta)) * (w_hat * w_hat);
+
+//     return mat;
+// }
+// Eigen::Matrix3d LieAlgebra::to_E(se3 se3){
     
-    Eigen::Matrix3d Rot, E;
-    Rot= LieAlgebra::to_SO3(se3.rot);
-    E.col(0)= Rot.col(0);
-    E.col(1)= Rot.col(1);
-    E.col(2)= se3.trans;
+//     Eigen::Matrix3d Rot, E;
+//     Rot= LieAlgebra::to_SO3(se3.rot);
+//     E.col(0)= Rot.col(0);
+//     E.col(1)= Rot.col(1);
+//     E.col(2)= se3.trans;
 
-    return E;
-}
+//     return E;
+// }
 
 Eigen::Matrix4d LieAlgebra::to_SE3(se3 se3){
     Eigen::Matrix4d T;

--- a/src/lib_calib/CMomentsTracker.cpp
+++ b/src/lib_calib/CMomentsTracker.cpp
@@ -45,112 +45,147 @@ void MomentsTracker::init(){
 
 }
 
-double MomentsTracker::nCr(int n, int r){
-    if(n> comb_max || n<r) throw MomentsTrackerError();
-    return (double)(comb_buffer[n][r]);
-}
+// double MomentsTracker::nCr(int n, int r){
+//     if(n> comb_max || n<r) throw MomentsTrackerError();
+//     return (double)(comb_buffer[n][r]);
+// }
+
 double MomentsTracker::_M_2i2j(int i, int j){
     // a, b == 1
-    double den= nCr(2*(i+j),i+j)*nCr(i+j,i);
-    double num= nCr(2*(i+j),2*i)*(i+j+1)*pow(2,2*(i+j));
+    double den= nCr<double>(2*(i+j),i+j)*nCr<double>(i+j,i);
+    double num= nCr<double>(2*(i+j),2*i)*(i+j+1)*pow(2,2*(i+j));
     // cout<<den<<num<<endl;
     return den/num;
     
 }
 double MomentsTracker::M_2i2j(int i, int j){
-    if(i> max_n || j>max_n) throw MomentsTrackerError();
+    if(i> max_n || j>max_n) throw MomentsTrackerError("M_2i2j error!!");
     else return moment_buffer[i][j];
-    
-}
-double MomentsTracker::M_2i2j(int i, int j, double a, double b){
-    // return M^{2i2j}
-    return M_2i2j(i,j)*pow(a,2*i)*pow(b,2*j);
 }
 
+// double MomentsTracker::M_2i2j(int i, int j, double a, double b){
+//     // return M^{2i2j}
+//     return M_2i2j(i,j)*pow(a,2*i)*pow(b,2*j);
+// }
 
-array<double ,3> MomentsTracker::intSn(int n,double a, double b, double tx, double ty, double alpha){
-    // is validated by wolframAlpha
-    double tx_s = cos(alpha)*tx+sin(alpha)*ty;
-    double ty_s = -sin(alpha)*tx+cos(alpha)*ty;
-    double s0=0,sx=0,sy=0;
-    array<double ,3> results;
+// array<double ,3> MomentsTracker::intSn(int n,double a, double b, double tx, double ty, double alpha){
+//     // is validated by wolframAlpha
+//     double tx_s = cos(alpha)*tx+sin(alpha)*ty;
+//     double ty_s = -sin(alpha)*tx+cos(alpha)*ty;
+//     double s0=0,sx=0,sy=0;
+//     array<double ,3> results;
 
-    for(int i=0;i<n+1;i++){
-        for(int j=0;j<n-i+1;j++){
-            double M = M_2i2j(i,j,a,b);
-            double m_0 =0;
-            double m_x =0;
-            double m_y =0;
-            for(int k=i;k<n-j+1;k++){
-                m_0+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k));
-                m_x+= nCr(n,k)*nCr(2*k+1,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i)+1)*pow(ty_s,2*(n-j-k));
-                m_y+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k)+1,2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k)+1);
+//     for(int i=0;i<n+1;i++){
+//         for(int j=0;j<n-i+1;j++){
+//             double M = M_2i2j(i,j,a,b);
+//             double m_0 =0;
+//             double m_x =0;
+//             double m_y =0;
+//             for(int k=i;k<n-j+1;k++){
+//                 m_0+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k));
+//                 m_x+= nCr(n,k)*nCr(2*k+1,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i)+1)*pow(ty_s,2*(n-j-k));
+//                 m_y+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k)+1,2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k)+1);
             
-            }
+//             }
             
-            s0 += m_0*M;
-            sx += m_x*M;
-            sy += m_y*M;
-            // printf("%d, %d : %e, %e, %e, %e\n",i,j,M,m_0,m_x,m_y);
-        }
-    }
+//             s0 += m_0*M;
+//             sx += m_x*M;
+//             sy += m_y*M;
+//             // printf("%d, %d : %e, %e, %e, %e\n",i,j,M,m_0,m_x,m_y);
+//         }
+//     }
 
-    // support plane to normal plane
-    results[0] = s0;
-    results[1] = cos(alpha)*sx - sin(alpha)*sy;
-    results[2] = sin(alpha)*sx + cos(alpha)*sy;
-    return results;
+//     // support plane to normal plane
+//     results[0] = s0;
+//     results[1] = cos(alpha)*sx - sin(alpha)*sy;
+//     results[2] = sin(alpha)*sx + cos(alpha)*sy;
+//     return results;
+// }
 
-}
-double MomentsTracker::C0n(int n,vector<double> ds){
-    double result=0;
-    int n_d =max_dim;
-    for(int i=max(0,n-n_d);i<min(n,n_d)+1;i++){
-        result+= (2*i+1)*ds[i]*ds[n-i];
-    }
-    return result;
-}
-double MomentsTracker::C1n(int n,vector<double> ds){
-    double result=0;
-    int n_d =max_dim;
-    for(int i=max(0,n-n_d*2);i<min(n,n_d)+1;i++){
-        double temp =0;
-        for(int j=max(0,n-i-n_d); j<min(n-i,n_d)+1;j++){
-            temp+= ds[j]*ds[n-i-j];
-        }
-        result+= (2*i+1)*ds[i]*temp;
-    }
-    return result;
-}
+// double MomentsTracker::C0n(int n,vector<double> ds){
+//     double result=0;
+//     int n_d =max_dim;
+//     for(int i=max(0,n-n_d);i<min(n,n_d)+1;i++){
+//         result+= (2*i+1)*ds[i]*ds[n-i];
+//     }
+//     return result;
+// }
 
-array<double, 5> MomentsTracker::ellipse2array(Eigen::Matrix3d Q){
-    double a=Q(0,0), b=Q(0,1), c=Q(1,1), d=Q(0,2), e=Q(1,2), f=Q(2,2);
-    double x,y,m0,m1,v0,v1;
-    double det_Q = Q.determinant();
-    double det_Q33 =  a*c-b*b;
-    double s = a+c;
-    x = (-c*d+b*e)/det_Q33;
-    y = (b*d-a*e)/det_Q33;
+// double MomentsTracker::C1n(int n,vector<double> ds){
+//     double result=0;
+//     int n_d =max_dim;
+//     for(int i=max(0,n-n_d*2);i<min(n,n_d)+1;i++){
+//         double temp =0;
+//         for(int j=max(0,n-i-n_d); j<min(n-i,n_d)+1;j++){
+//             temp+= ds[j]*ds[n-i-j];
+//         }
+//         result+= (2*i+1)*ds[i]*temp;
+//     }
+//     return result;
+// }
 
-    double k = - det_Q/det_Q33;
-    double root = sqrt(pow(a-c,2)+4*pow(b,2));
-    double lamda0 = (s-root)/2;
-    double lamda1 = (s+root)/2;
-    m0 = sqrt(k/lamda0);
-    m1 = sqrt(k/lamda1);
-    if (b==0){
-        v0 = 0;
-        v1 = 1;
-    }
-    else{
-        v0 = ((c-a)+root)/2;
-        v1 = -b;
-    }
-    double alpha = atan2(v1,v0);
 
-    array<double, 5> result ={x,y,m0,m1,alpha};
-    return result;
-}
+// array<double, 5> MomentsTracker::ellipse2array(Eigen::Matrix3d Q){
+//     double a=Q(0,0), b=Q(0,1), c=Q(1,1), d=Q(0,2), e=Q(1,2), f=Q(2,2);
+//     double x,y,m0,m1,v0,v1;
+//     double det_Q = Q.determinant();
+//     double det_Q33 =  a*c-b*b;
+//     double s = a+c;
+//     x = (-c*d+b*e)/det_Q33;
+//     y = (b*d-a*e)/det_Q33;
+
+//     double k = - det_Q/det_Q33;
+//     double root = sqrt(pow(a-c,2)+4*pow(b,2));
+//     double lamda0 = (s-root)/2;
+//     double lamda1 = (s+root)/2;
+//     m0 = sqrt(k/lamda0);
+//     m1 = sqrt(k/lamda1);
+//     if (b==0){
+//         v0 = 0;
+//         v1 = 1;
+//     }
+//     else{
+//         v0 = ((c-a)+root)/2;
+//         v1 = -b;
+//     }
+//     double alpha = atan2(v1,v0);
+
+//     array<double, 5> result ={x,y,m0,m1,alpha};
+//     return result;
+// }
+
+
+// Point MomentsTracker::ne2dp(Eigen::Matrix3d Q, vector<double> ds){
+//     /*
+//     input: ellips in normal plane and distortion parameter
+//     output: centor point of region of distorted ellipse
+//     */
+
+//     array<double, 5> ellipse = ellipse2array(Q);
+
+//     double a,b,tx,ty,alpha;
+//     tx = ellipse[0];
+//     ty = ellipse[1];
+//     a = ellipse[2];
+//     b = ellipse[3];
+//     alpha = ellipse[4];
+//     double A_d=0; // =Ad/An
+//     double x_d=0;
+//     double y_d=0;
+
+//     for(int n=0;n<3*max_dim+1;n++){
+//         double c_0n = C0n(n,ds);
+//         double c_1n = C1n(n,ds);
+//         array<double,3> all_Sn = intSn(n,a,b,tx,ty,alpha);
+//         A_d+= c_0n * all_Sn[0];
+//         x_d += c_1n * all_Sn[1];
+//         y_d += c_1n * all_Sn[2];
+//     }
+
+//     x_d = x_d / A_d;
+//     y_d = y_d / A_d;
+//     return Point(x_d, y_d);
+// }
 
 Point MomentsTracker::ne2dp(Eigen::Matrix3d Q, vector<double> ds){
     /*
@@ -158,30 +193,7 @@ Point MomentsTracker::ne2dp(Eigen::Matrix3d Q, vector<double> ds){
     output: centor point of region of distorted ellipse
     */
 
-    array<double, 5> ellipse = ellipse2array(Q);
-
-    double a,b,tx,ty,alpha;
-    tx = ellipse[0];
-    ty = ellipse[1];
-    a = ellipse[2];
-    b = ellipse[3];
-    alpha = ellipse[4];
-    double A_d=0; // =Ad/An
-    double x_d=0;
-    double y_d=0;
-
-    for(int n=0;n<3*max_dim+1;n++){
-        double c_0n = C0n(n,ds);
-        double c_1n = C1n(n,ds);
-        array<double,3> all_Sn = intSn(n,a,b,tx,ty,alpha);
-        A_d+= c_0n * all_Sn[0];
-        x_d += c_1n * all_Sn[1];
-        y_d += c_1n * all_Sn[2];
-    }
-
-    x_d = x_d / A_d;
-    y_d = y_d / A_d;
-    return Point(x_d, y_d);
+    return ne2dp<double>(Q, ds);
 }
 
 Point MomentsTracker::distort_Point(Point pn, vector<double> ds){
@@ -391,46 +403,7 @@ Point MomentsTracker::ne2dp_Numerical(Eigen::Matrix3d Q, vector<double> ds){
 }
 
 
-Point MomentsTracker::project(double wx, double wy, double r,Params intrinsic, Eigen::Matrix3d E, int mode){
-    Eigen::Matrix3d Cw;
-    Cw <<   1.0, 0.0, -wx,
-            0.0, 1.0, -wy,
-            -wx, -wy, pow(wx,2)+pow(wy,2)-pow(r,2);
+Point MomentsTracker::project(double wx, double wy, double r, Params intrinsic, Eigen::Matrix3d E, int mode) {
+    return project<double>(wx, wy, r, intrinsic, E, mode);
 
-    vector<double> ds = {1, intrinsic.d[0], intrinsic.d[1],intrinsic.d[2],intrinsic.d[3]};
-    Point dp(0,0);
-    if(mode ==0){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        dp = ne2dp(Qn,ds);
-    }
-    else if(mode == 1){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        array<double,5> ellipse_n= ellipse2array(Qn);
-        Point pn(ellipse_n[0],ellipse_n[1]);
-        dp = distort_Point(pn,ds);
-    }
-    else if(mode == 2){
-        Eigen::Vector3d Pw{wx,wy,1};
-        Eigen::Vector3d Pn = E*Pw;
-        Point pn(Pn[0]/Pn[2],Pn[1]/Pn[2]);
-        dp = distort_Point(pn,ds);
-    }
-    else if(mode == 3){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        dp = ne2dp_Numerical(Qn,ds);
-    }
-    else if(mode == 4){
-        dp = wc2dp_Numerical(Cw,E,ds);
-    }
-    else{
-        throw MomentsTrackerError();
-    }
-
-    double u_e = dp.x*intrinsic.fx+dp.y*intrinsic.skew+intrinsic.cx; 
-    double v_e = dp.y*intrinsic.fy+intrinsic.cy;
-
-    return Point(u_e, v_e);
 }

--- a/src/lib_detect/CTargetDetector.cpp
+++ b/src/lib_detect/CTargetDetector.cpp
@@ -25,24 +25,28 @@ TargetDetector::TargetDetector(int n_x, int n_y, bool draw){
     }
 }
 
+//modified
 cv::Mat TargetDetector::preprocessing(const cv::Mat img, string detection_mode){
-    cv::Mat output_img;
+    // cv::Mat filltered_img, gray_img;
+    // cv::bilateralFilter(img,filltered_img,-1,10,10);
+    // filltered_img = img.clone();
+    
+    cv::Mat gray_img;
+
     if(img.channels()==3){
-        
         if(detection_mode == "saturation"){
             cv::Mat hsv_img;
             cv::cvtColor(img, hsv_img, cv::COLOR_BGR2HSV);
-            cv::extractChannel(hsv_img, output_img, 1);
+            cv::extractChannel(hsv_img, gray_img, 1);
         }
         else{
-            cv::cvtColor(img, output_img, cv::COLOR_BGR2GRAY);
+            cv::cvtColor(img, gray_img, cv::COLOR_BGR2GRAY);
         }
         
-        return output_img;
+        return gray_img;
     }
     else if(img.channels()==1){
-        cv::bilateralFilter(img,output_img,-1,10,10);
-        return output_img;
+        return img;
     }
     else{
         throw WrongTypeException();
@@ -86,7 +90,8 @@ void TargetDetector::update_autocorrelation(cv::Mat &src, vector<Shape>& control
     }
 }
 
-pair<bool,vector<Shape>> TargetDetector::detect(cv::Mat& img, string type){
+//modified: key_input
+pair<bool,vector<Shape>> TargetDetector::detect(cv::Mat& img, string type, bool key_input){
     if(this->draw){
         this->drawing_scale = 1000.0/max(img.rows, img.cols);
     }
@@ -120,7 +125,7 @@ pair<bool,vector<Shape>> TargetDetector::detect(cv::Mat& img, string type){
     final_result.first = ret;
     final_result.second = control_shapes;
 
-    visualize_result(output_img, final_result);
+    visualize_result(output_img, final_result, key_input);
     return final_result;
 }
 
@@ -128,7 +133,8 @@ void TargetDetector::save_result(string path){
     cv::imwrite(path, this->detection_result);
 }
 
-void TargetDetector::visualize_result(cv::Mat& img_output, pair<bool,vector<Shape>> &result){
+//modified: key_input
+void TargetDetector::visualize_result(cv::Mat& img_output, pair<bool,vector<Shape>> &result, bool key_input){
     // visualize
     int scale= 100/this->drawing_scale;
     if(result.first){
@@ -163,25 +169,32 @@ void TargetDetector::visualize_result(cv::Mat& img_output, pair<bool,vector<Shap
     float left = img_output.cols*0.05;
     double fontscale = 1.2;
     int thickness = 3;
-    if(this->draw){
-        if(result.first) cv::putText(img_output,"save: 1, ignore: 0, quit_visualize: q",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
-        else cv::putText(img_output,"detection fail, press any key",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
-        this->detection_result = img_output;
 
-        cv::imshow("input_image",img_output);
-        printf("Interact with the visualization window\n");
-        char key = cv::waitKey(0);
-        
-        if(key != '0' && key!='1' && key!='q'){
-            printf("wrong commend is detected\n");
-            key = cv::waitKey(0);
+
+    if(this->draw){
+        if(key_input) {
+            if(result.first) cv::putText(img_output,"save: 1, ignore: 0",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
+            else cv::putText(img_output,"detection fail, press any key",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
+            this->detection_result = img_output;
+
+            cv::imshow("input_image",img_output);
+            printf("save: 1, ignore: 0\n");
+            char key = cv::waitKey(0);
+            while(key != '0' && key!='1'){
+                printf("wrong commend is detected\n");
+                key = cv::waitKey(0);
+            }
+            cv::destroyAllWindows();
+            if(key == '0'){
+                result.first = false;
+            }
         }
-        cv::destroyAllWindows();
-        if(key == '0'){
-            result.first = false;
-        }
-        if(key == 'q'){
-            this->draw = false;
+        else {
+            if(result.first) cv::putText(img_output,"detection success",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
+            else cv::putText(img_output,"detection fail",cv::Point2f(left,bottom),0,fontscale,cv::Scalar(0,0,255),thickness);
+            this->detection_result = img_output;
+
+            cv::imshow("input_image",img_output);
         }
     }
     else{
@@ -293,6 +306,8 @@ Shape TargetDetector::contour2shape(const vector<cv::Point2i> &contour){
     double m00{0}, m10{0}, m01{0}, m20{0},m11{0},m02{0};
     double M00{0}, M10{0}, M01{0}, M20{0},M11{0},M02{0};
 
+    #pragma omp prallel for \
+    reduction(+: M00) reduction(+: M10) reduction(+: M01) reduction(+: M20) reduction(+: M11) reduction(+: M02)
     for(int i=0; i<n;i++){
         cv::Point2i pt = contour[i];
         int x_f = pt.x;
@@ -346,79 +361,76 @@ bool TargetDetector::cal_shape_cov(const vector<cv::Point2i> &contour, Shape* sh
     J10.setZero();
     J01.setZero();
     Jc.setZero();
-    
+    // Eigen::MatrixXd p_info(2*n, 2*n);
+    // p_info.setZero();
+
+    Eigen::SparseMatrix<double> sparse_p_info(2*n, 2*n);
+
     double s = pow(1,2);
     double z=1/s*2/3;
+    #pragma omp prallel for
+    for(int i=0;i<n;i++){
+        int curr_x_index = 2*i;
+        int curr_y_index = (curr_x_index+1)%(2*n);
+        int next_x_index = (curr_x_index+2)%(2*n);
+        int next_y_index = (curr_x_index+3)%(2*n);
+
+        sparse_p_info.insert(curr_x_index,next_x_index)=-z;
+        sparse_p_info.insert(next_x_index,curr_x_index)=-z;
+
+        sparse_p_info.insert(curr_y_index,next_y_index)=-z;
+        sparse_p_info.insert(next_y_index,curr_y_index)=-z;
+    }
+
     float * grad_x3_ptr = (float*) grad_x3.data;
     float * grad_y3_ptr = (float*) grad_y3.data;
 
-    std::vector<Eigen::Triplet<double>> triplets;
-    triplets.reserve(10 * n);
-    #pragma omp parallel
-    {
-        std::vector<Eigen::Triplet<double>> local_triplets;
 
-        #pragma omp for nowait
-        for (int i = 0; i < n; i++) {
-            int curr_x_index = 2 * i;
-            int curr_y_index = (curr_x_index + 1) % (2 * n);
-            int next_x_index = (curr_x_index + 2) % (2 * n);
-            int next_y_index = (curr_x_index + 3) % (2 * n);
+    #pragma omp prallel for
+    for(int i=0; i<n;i++){
+        int i_p = (i-1+n)%n;
+        cv::Point2i pt_p = contour[i_p];
+        int x_p = pt_p.x;
+        int y_p = pt_p.y;
 
-            local_triplets.emplace_back(curr_x_index, next_x_index, -z);
-            local_triplets.emplace_back(next_x_index, curr_x_index, -z);
-            local_triplets.emplace_back(curr_y_index, next_y_index, -z);
-            local_triplets.emplace_back(next_y_index, curr_y_index, -z);
-        }
+        int i_c= i;
+        cv::Point2i pt_c = contour[i_c];
+        int x_c = pt_c.x;
+        int y_c = pt_c.y;
 
-        #pragma omp for nowait
-        for (int i = 0; i < n; i++) {
-            int i_p = (i - 1 + n) % n;
-            int i_c = i;
-            int i_f = (i + 1) % n;
+        int i_f= (i+1)%n;
+        cv::Point2i pt_f = contour[i_f];
+        int x_f = pt_f.x;
+        int y_f = pt_f.y;
 
-            cv::Point2i pt_p = contour[i_p];
-            cv::Point2i pt_c = contour[i_c];
-            cv::Point2i pt_f = contour[i_f];
+        J00(2*i_c) = y_p - y_f;
+        J00(2*i_c+1) = x_f - x_p;
+        J10(2*i_c) = x_f*(y_c-y_f) + 2*x_c*(y_p-y_f)+x_p*(y_p-y_c);
+        J10(2*i_c+1) = (x_f-x_p)*(x_f+x_c+x_p);
+        J01(2*i_c) = (y_p-y_f)*(y_f+y_c+y_p);
+        J01(2*i_c+1) = y_f*(x_f-x_c) + 2*y_c*(x_f-x_p)+y_p*(x_c-x_p);
 
-            int x_p = pt_p.x, y_p = pt_p.y;
-            int x_c = pt_c.x, y_c = pt_c.y;
-            int x_f = pt_f.x, y_f = pt_f.y;
+        int pos = y_c*width +x_c;
+        float gx_i = grad_x3_ptr[pos];
+        float gy_i = grad_y3_ptr[pos];
+        float gn_i = sqrt(gx_i*gx_i+gy_i*gy_i) + numerical_stable;
+        float step_x = gx_i/gn_i;
+        float step_y = gy_i/gn_i;
+        double delta = intensity_range(gray_img, x_c,y_c,step_x, step_y, step_length)+0.0;
+        Eigen::Matrix2d V,W, likelihood_i;
+        V << step_x , -step_y,
+             step_y , step_x;
+        W << pow(gn_i*4/delta,2) , 0,0,0;
+        likelihood_i = V*W*V.transpose();
+        
+        // cout<<likelihood_i<<endl;
 
-            J00(2 * i_c) = y_p - y_f;
-            J00(2 * i_c + 1) = x_f - x_p;
-            J10(2 * i_c) = x_f * (y_c - y_f) + 2 * x_c * (y_p - y_f) + x_p * (y_p - y_c);
-            J10(2 * i_c + 1) = (x_f - x_p) * (x_f + x_c + x_p);
-            J01(2 * i_c) = (y_p - y_f) * (y_f + y_c + y_p);
-            J01(2 * i_c + 1) = y_f * (x_f - x_c) + 2 * y_c * (x_f - x_p) + y_p * (x_c - x_p);
+        sparse_p_info.insert(2*i_c,2*i_c) = likelihood_i(0,0)+2*z+numerical_stable;;
+        sparse_p_info.insert(2*i_c+1,2*i_c) = likelihood_i(1,0);
+        sparse_p_info.insert(2*i_c,2*i_c+1) = likelihood_i(0,1);
+        sparse_p_info.insert(2*i_c+1,2*i_c+1) = likelihood_i(1,1)+2*z+numerical_stable;;
 
-            int pos = y_c * width + x_c;
-            float gx_i = grad_x3_ptr[pos];
-            float gy_i = grad_y3_ptr[pos];
-            float gn_i = sqrt(gx_i * gx_i + gy_i * gy_i) + numerical_stable;
-            float step_x = gx_i / gn_i;
-            float step_y = gy_i / gn_i;
-            double delta = intensity_range(gray_img, x_c, y_c, step_x, step_y, step_length) + 0.0;
-
-            Eigen::Matrix2d V, W, likelihood_i;
-            V << step_x, -step_y,
-                step_y,  step_x;
-            W << pow(gn_i * 4 / delta, 2), 0,
-                0, 0;
-            likelihood_i = V * W * V.transpose();
-
-            int idx = 2 * i_c;
-            local_triplets.emplace_back(idx,     idx,     likelihood_i(0,0) + 2 * z + numerical_stable);
-            local_triplets.emplace_back(idx + 1, idx,     likelihood_i(1,0));
-            local_triplets.emplace_back(idx,     idx + 1, likelihood_i(0,1));
-            local_triplets.emplace_back(idx + 1, idx + 1, likelihood_i(1,1) + 2 * z + numerical_stable);
-        }
-
-        #pragma omp critical
-        triplets.insert(triplets.end(), local_triplets.begin(), local_triplets.end());
     }
-    Eigen::SparseMatrix<double> sparse_p_info(2 * n, 2 * n);
-    sparse_p_info.setFromTriplets(triplets.begin(), triplets.end());
 
 
     double M00 = shape->m00*2;
@@ -477,8 +489,7 @@ bool TargetDetector::detect_circles(cv::Mat& img, cv::Mat& img_output,vector<Sha
     cv::Mat img_thresh, img_morph;
     int scale_factor = max(img_origin.rows, img_origin.cols)/1000+1;
     int blur_size = scale_factor*2+3; //should be odd
-    // cv::GaussianBlur(img_origin, img_blur, cv::Size(blur_size, blur_size), -1);
-    img_blur = img_origin;
+    cv::GaussianBlur(img_origin, img_blur, cv::Size(blur_size, blur_size), -1);
 
     // threshold based
     vector<int> block_sizes = {6*scale_factor+1,12*scale_factor+1,18*scale_factor+1};


### PR DESCRIPTION
optimize 관련 함수(update_Es, batch_optimize)에서 기존 NumericalDiffCostFunction을 AutoDiffCostFunction으로 변경했습니다.
이를 위해 기존에 구현되어있던 MomentTracker, Calibrator, LieAlgebra 부분을 template으로 변경했고,
기존 구조체 (Params, Point, so3, se3)를 template으로(Params_T, Point_T, so3_T, se3_T) 변경했습니다.

typedef Params_T<double> Params;

이런 식으로 정의해두었기 때문에 원래 쓰던 type도 사용가능합니다.

sample_images에 대해 mono.out, stereo.out은 잘 작동하는 점 확인했습니다.