### PR TITLE
Switch to AutoDiffCostFunction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .vscode/
 build/
+install/
+log/
 sample_imgs/rgb
 sample_imgs/tir
 run_mono

--- a/include/CCalibrator.h
+++ b/include/CCalibrator.h
@@ -112,46 +112,56 @@ struct CalibrationFunctor {
 
     template <typename T>
     bool operator()(const T* const fcs, const T* const distorsion, const T* const rot, const T* const trans,T* residual) const {
-        for(int i=0;i<origin_target.size();i++){
-            double wx = origin_target[i].x;
-            double wy = origin_target[i].y;
-            // double radius = 0.05;
-            Params params = {fcs[0],fcs[1],fcs[2],fcs[3], fcs[4], distorsion[0],distorsion[1],distorsion[2],distorsion[3]};
-            Eigen::Matrix3d E, E_inv, Qn;
-            Eigen::Vector3d rot_vector{rot[0],rot[1],rot[2]};  
+        for(size_t i=0; i<origin_target.size(); i++) {
+            T wx = static_cast<T>(origin_target[i].x);
+            T wy = static_cast<T>(origin_target[i].y);
+            
+            Params_T<T> params = {
+                fcs[0], fcs[1], fcs[2], fcs[3], fcs[4], 
+                distorsion[0], distorsion[1], distorsion[2], distorsion[3]
+            };
+            
+            Eigen::Matrix<T, 3, 3> E;
+            Eigen::Matrix<T, 3, 1> rot_vector;
+            rot_vector << rot[0], rot[1], rot[2];
+            
             rot_vector = LieAlgebra::normalize_so3(rot_vector);
-            E= LieAlgebra::to_E(se3(rot_vector,Eigen::Vector3d(trans[0],trans[1],trans[2])));
 
-            Point p_i = tracker->project(wx, wy, radius, params, E,mode);
-            double u_e = p_i.x;
-            double v_e = p_i.y;
+            Eigen::Matrix<T, 3, 1> trans_vector;
+            trans_vector << trans[0], trans[1], trans[2];
+            
+            E = LieAlgebra::to_E(se3_T<T>(rot_vector, trans_vector));
 
-            double u_o = target[i].x;
-            double v_o = target[i].y;
+            Point_T<T> p_i = tracker->project<T>(wx, wy, static_cast<T>(radius), params, E, mode);
+            T u_e = p_i.x;
+            T v_e = p_i.y;
 
-            double c1 = 1;
-            double c2 = 0;
-            double c3 = 1;
+            T u_o = static_cast<T>(target[i].x);
+            T v_o = static_cast<T>(target[i].y);
+
+            T c1 = T(1.0);
+            T c2 = T(0.0);
+            T c3 = T(1.0);
 
             if(use_weight){
-                Eigen::Matrix2d cov;
-                cov<<target[i].Kxx , target[i].Kxy , target[i].Kxy , target[i].Kyy;
-                Eigen::LLT<Eigen::Matrix2d> lltOfA(cov.inverse()); // compute the Cholesky decomposition of A
-                Eigen::Matrix2d L = lltOfA.matrixL(); 
+                Eigen::Matrix<T, 2, 2> cov;
+                cov << static_cast<T>(target[i].Kxx), static_cast<T>(target[i].Kxy), 
+                    static_cast<T>(target[i].Kxy), static_cast<T>(target[i].Kyy);
+
+                Eigen::LLT<Eigen::Matrix<T, 2, 2>> lltOfA(cov.inverse());
+                Eigen::Matrix<T, 2, 2> L = lltOfA.matrixL(); 
                 c1= L(0,0);
                 c2= L(1,0);
                 c3= L(1,1);
             }
 
-            residual[2*i]= c1*(u_o-u_e)+c2*(v_o-v_e);
-            residual[2*i+1]= c3*(v_o-v_e);  
-
-
-
-              
+            residual[2*i] = c1*(u_o-u_e)+c2*(v_o-v_e);
+            residual[2*i+1] = c3*(v_o-v_e);
         }
         
         return true;
+
+              
     }
     private:
         int mode;

--- a/include/CLieAlgebra.h
+++ b/include/CLieAlgebra.h
@@ -4,6 +4,7 @@
 
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include "ceres/ceres.h"
 #include <math.h>
 #include <random>
 #include <iostream>
@@ -14,20 +15,67 @@ class LieAlgebraError: public std::exception{
             return "LieAlgebra error";
         }
 };
-struct so3{
-    Eigen::Vector3d w;
+
+
+template <typename T>
+struct so3_T{
+    Eigen::Matrix<T, 3, 1> w;
 };
-struct se3{
-    Eigen::Vector3d rot;
-    Eigen::Vector3d trans;
-    se3(Eigen::Vector3d _rot, Eigen::Vector3d _trans) : rot(_rot), trans(_trans){};
-    se3() : rot(Eigen::Vector3d::Zero()), trans(Eigen::Vector3d::Zero()){};
-    std::string to_string(){
+
+template <typename T>
+struct se3_T{
+    Eigen::Matrix<T, 3, 1> rot;
+    Eigen::Matrix<T, 3, 1> trans;
+    se3_T(const Eigen::Matrix<T, 3, 1>& _rot, const Eigen::Matrix<T, 3, 1>& _trans) : rot(_rot), trans(_trans){};
+    se3_T() : rot(Eigen::Matrix<T, 3, 1>::Zero()), trans(Eigen::Matrix<T, 3, 1>::Zero()){};
+    std::string to_string() const {
         std::string message = std::to_string(rot(0))+"\t"+std::to_string(rot(1))+"\t"+std::to_string(rot(2))+
         "\t"+std::to_string(trans(0))+"\t"+std::to_string(trans(1))+"\t"+std::to_string(trans(2));
         return message;
     }
+    se3_T from_string(const std::string& str) {
+        se3_T result;
+        std::stringstream ss(str);
+        std::string segment;
+        std::vector<double> values;
+
+        for (int i=0; i<6; i++) {
+            if (std::getline(ss, segment, '\t')) {
+                try {
+                    values.push_back(std::stod(segment));
+                }
+                catch (const std::invalid_argument& e) {
+                    throw std::runtime_error("from_string: Invalid number format in segment '" + segment + "': " + e.what());
+                }
+                catch (const std::out_of_range& e) {
+                    throw std::runtime_error("from_string: Number out of range in segment '" + segment + "': " + e.what());
+                }
+            }
+            else {
+                throw std::runtime_error("from_string: Not enough segments in string. Expected 6, got " + std::to_string(i));
+            }
+        }
+
+        if (values.size() != 6) {
+            throw std::runtime_error("from_string: Incorrect number of values parsed. Expected 6, got " + std::to_string(values.size()));
+        }
+
+        result.rot(0) = values[0];
+        result.rot(1) = values[1];
+        result.rot(2) = values[2];
+        result.trans(0) = values[3];
+        result.trans(1) = values[4];
+        result.trans(2) = values[5];
+
+        return result;
+    }
 };
+
+typedef so3_T<double> so3;
+
+typedef se3_T<double> se3;
+
+
 
 using namespace std;
 
@@ -35,10 +83,6 @@ class LieAlgebra{
     public:
         // transformation between matrix form and screw vector fom
         static Eigen::Matrix3d randomE(Eigen::Vector3d standard, double delta);
-        static Eigen::Vector3d to_so3(const Eigen::Matrix3d &R);
-        static Eigen::Vector3d normalize_so3(const Eigen::Vector3d &_w);
-        static Eigen::Matrix3d to_SO3(const Eigen::Vector3d &_w);
-        static Eigen::Matrix3d to_E(se3 se3);
         static Eigen::Matrix4d to_SE3(se3 se3);
         static se3 to_se3(const Eigen::Matrix4d &T);
         static se3 to_se3(const Eigen::Matrix3d &E);
@@ -46,10 +90,91 @@ class LieAlgebra{
         static se3 solveAXXB(const vector<pair<se3, se3>> &ABs);
 
 
+        //template ftn
+        template<typename T>
+        static Eigen::Matrix<T, 3, 1> to_so3(const Eigen::Matrix<T, 3, 3> &R) {
+            T trace_R = R.trace();
+            if(trace_R > T(3.) || trace_R < T(-3.)) {
+                cout<< R*R.transpose()<<endl;
+                throw LieAlgebraError();
+            }
+
+            T theta = ceres::acos((trace_R - T(1.0)) / T(2.0));
+
+            if (ceres::abs(theta) < T(1e-12)) return Eigen::Matrix<T, 3, 1>::Zero();
+
+            Eigen::Matrix<T, 3, 3> skew_m = (theta / (T(2.) * ceres::sin(theta))) * (R - R.transpose()); // ceres::sin
+            Eigen::Matrix<T, 3, 1> skew_v(skew_m(2, 1), skew_m(0, 2), skew_m(1, 0));
+            return skew_v;
+        }
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 1> normalize_so3(const Eigen::Matrix<T, 3, 1> &_w) {
+            Eigen::Matrix<T, 3, 1> w = _w;
+            T norm_w = w.norm();
+            T scale = norm_w / T(M_PI);
+
+            if (scale > T(1)) {
+                int share;
+
+                if constexpr (std::is_same_v<T, double>) {
+                    share = static_cast<int>(ceres::floor(scale));
+                }
+                else {
+                    share = static_cast<int>(ceres::floor(scale).a);
+                }
+
+                if (share % 2 == 0) {
+                    w = w / scale * (scale - T(static_cast<double>(share)));
+                }
+                else {
+                    w = w / scale * (scale - T(static_cast<double>(share)) - T(1));
+                }
+            }
+            return w;
+        }
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> to_SO3(const Eigen::Matrix<T, 3, 1> & _w) {
+            Eigen::Matrix<T, 3, 1> w = normalize_so3(_w);
+            T theta = w.norm();
+
+            if (ceres::abs(theta) < T(1e-12))
+                return Eigen::Matrix<T, 3, 3>::Identity();
+
+            Eigen::Matrix<T, 3, 3> w_hat = skew_symmetric_matrix(w);
+            Eigen::Matrix<T, 3, 3> mat = Eigen::Matrix<T, 3, 3>::Identity() + (ceres::sin(theta) / theta) * w_hat + ((T(1.0) - ceres::cos(theta)) / (theta * theta)) * (w_hat * w_hat);
+
+            return mat;
+        }
+
+
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> to_E(se3_T<T> se3_val) {
+            Eigen::Matrix<T, 3, 3> Rot, E;
+            Rot = LieAlgebra::to_SO3(se3_val.rot);
+            E.col(0)= Rot.col(0);
+            E.col(1)= Rot.col(1);
+            E.col(2)= se3_val.trans;
+
+            return E;
+        }
+
+
 
     private:
         static Eigen::Vector3d random_vector(double min, double max);
         static Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v);
+
+        //template ftn
+        template<typename T>
+        static Eigen::Matrix<T, 3, 3> skew_symmetric_matrix(const Eigen::Matrix<T, 3, 1> &v) {
+            Eigen::Matrix<T, 3, 3> skew;
+            skew << T(0.), -v(2), v(1),
+                    v(2), T(0.), -v(0),
+                    -v(1), v(0), T(0.);
+            return skew;
+        }
 
 };
 

--- a/include/CMomentsTracker.h
+++ b/include/CMomentsTracker.h
@@ -7,6 +7,7 @@
 #include "math.h"
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include "ceres/ceres.h"
 #include "utils.h"
 using namespace std;
 
@@ -27,13 +28,79 @@ private:
     vector<vector<double>> moment_buffer;
     void init();
     double _M_2i2j(int i, int j);
-    double C0n(int n, vector<double> ds);
-    double C1n(int n, vector<double> ds);
-    double nCr(int i, int j);
     double I_2i2j(int i, int j);
     double M_2i2j(int i, int j);
-    double M_2i2j(int i, int j, double a, double b);
-    array<double ,3> intSn(int n,double a, double b, double tx, double ty,double alpha);
+
+
+    //template ftn
+    template<typename T>
+    T C0n(int n, const std::vector<T>& ds) {
+        T result = T(0);
+        int n_d = max_dim;
+        for (int i = std::max(0, n - n_d); i < std::min(n, n_d) + 1; i++) {
+            result += T(2 * i + 1) * ds[i] * ds[n - i];
+        }
+        return result;
+    }
+
+    template<typename T>
+    T C1n(int n, const std::vector<T>& ds) {
+        T result = T(0);
+        int n_d = max_dim;
+        for (int i = std::max(0, n - n_d * 2); i < std::min(n, n_d) + 1; i++) {
+            T temp = T(0);
+            for (int j = std::max(0, n - i - n_d); j < std::min(n - i, n_d) + 1; j++) {
+                temp += ds[j] * ds[n - i - j];
+            }
+            result += T(2 * i + 1) * ds[i] * temp;
+        }
+        return result;
+    }
+
+    template<typename T>
+    T nCr(int n, int r) {
+        if (n > comb_max || n < r) throw MomentsTrackerError();
+        return T(static_cast<double>(comb_buffer[n][r]));  
+    }
+
+    template<typename T>
+    T M_2i2j(int i, int j, T a, T b) {
+        T base_M_val = T(MomentsTracker::M_2i2j(i, j));
+        return base_M_val * ceres::pow(a, T(2 * i)) * ceres::pow(b, T(2 * j)); 
+    }
+
+    template<typename T>
+    array<T, 3> intSn(int n, T a, T b, T tx, T ty, T alpha) {
+        T tx_s = ceres::cos(alpha) * tx + ceres::sin(alpha) * ty;
+        T ty_s = -ceres::sin(alpha) * tx + ceres::cos(alpha) * ty;
+        T s0 = T(0), sx = T(0), sy = T(0);
+        std::array<T, 3> results;
+
+        for (int i = 0; i < n + 1; i++) {
+            for (int j = 0; j < n - i + 1; j++) {
+                T M = M_2i2j(i, j, a, b);
+                T m_0 = T(0);
+                T m_x = T(0);
+                T m_y = T(0);
+                for (int k = i; k < n - j + 1; k++) {
+                    m_0 += nCr<double>(n, k) * nCr<double>(2 * k, 2 * i) * nCr<double>(2 * (n - k), 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i))) * ceres::pow(ty_s, T(2 * (n - j - k)));
+                    m_x += nCr<double>(n, k) * nCr<double>(2 * k + 1, 2 * i) * nCr<double>(2 * (n - k), 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i) + 1)) * ceres::pow(ty_s, T(2 * (n - j - k)));
+                    m_y += nCr<double>(n, k) * nCr<double>(2 * k, 2 * i) * nCr<double>(2 * (n - k) + 1, 2 * j) *
+                        ceres::pow(tx_s, T(2 * (k - i))) * ceres::pow(ty_s, T(2 * (n - j - k) + 1));
+                }
+                s0 += m_0 * M;
+                sx += m_x * M;
+                sy += m_y * M;
+            }
+        }
+        results[0] = s0;
+        results[1] = ceres::cos(alpha) * sx - ceres::sin(alpha) * sy;
+        results[2] = ceres::sin(alpha) * sx + ceres::cos(alpha) * sy;
+        return results;
+    }
+
     
 
 public:
@@ -43,11 +110,254 @@ public:
 
 
     Point ne2dp(Eigen::Matrix3d Q, vector<double> ds);
+
     Point wc2dp_Numerical(Eigen::Matrix3d Cw,Eigen::Matrix3d H, vector<double> ds,int total_iter=1600);
     Point ne2dp_Numerical(Eigen::Matrix3d Q, vector<double> ds);
+    
     Point project(double wx, double wy, double r,Params intrinsic, Eigen::Matrix3d E, int mode);
-    array<double, 5> ellipse2array(Eigen::Matrix3d Q);
+
     Point distort_Point(Point pn, vector<double> ds);
+
+
+    //template ftn
+    template<typename T>
+    Point_T<T> wc2dp_Numerical(Eigen::Matrix<T, 3, 3> Cw, Eigen::Matrix<T, 3, 3> H, std::vector<T> ds, int total_iter = 1600) {
+        int iter = (int)(sqrt(total_iter));
+        T A_d = T(0);
+        T x_d = T(0);
+        T y_d = T(0);
+
+        T t_x = -Cw(0, 2);
+        T t_y = -Cw(1, 2);
+        T R = ceres::sqrt(-Cw(2, 2) + ceres::pow(t_x, 2) + ceres::pow(t_y, 2));
+        T r_step = T(1.0) / T(iter);
+        T t_step = T(2 * M_PI) / T(iter);
+
+        for (int i = 0; i < iter + 1; i++) {
+            for (int j = 0; j < iter + 1; j++) {
+                T r = r_step * (T(i) + T(0.5));
+                T t = t_step * (T(j) + T(0.5));
+
+                T x_w = t_x + R * r * ceres::cos(t);
+                T y_w = t_y + R * r * ceres::sin(t);
+                T f = H(0, 0) * x_w + H(0, 1) * y_w + H(0, 2);
+                T g = H(1, 0) * x_w + H(1, 1) * y_w + H(1, 2);
+                T h = H(2, 0) * x_w + H(2, 1) * y_w + H(2, 2);
+                T x_n = f / h;
+                T y_n = g / h;
+
+                T H02 = H(1, 0) * H(2, 1) - H(1, 1) * H(2, 0);
+                T H12 = H(0, 0) * H(2, 1) - H(0, 1) * H(2, 0);
+                T H22 = H(0, 0) * H(1, 1) - H(0, 1) * H(1, 0);
+
+                T Jwrt = R * R * r;
+                T Jnw = (H02 * f / h - H12 * g / h + H22) / ceres::pow(h, 2);
+
+                T s_n = ceres::pow(x_n, 2) + ceres::pow(y_n, 2);
+                T tmp1 = T(0);
+                T tmp2 = T(0);
+                for (int k = 0; k < max_dim + 1; k++) {
+                    tmp1 += ds[k] * ceres::pow(s_n, k);
+                    tmp2 += (T(2 * k + 1)) * ds[k] * ceres::pow(s_n, k);
+                }
+                T Jdn = tmp1 * tmp2;
+
+                T x_d_t = tmp1 * x_n;
+                T y_d_t = tmp1 * y_n;
+
+                T J = Jdn * Jnw * Jwrt;
+
+                A_d += J * r_step * t_step;
+                x_d += x_d_t * J * r_step * t_step;
+                y_d += y_d_t * J * r_step * t_step;
+            }
+        }
+
+        x_d = x_d / A_d;
+        y_d = y_d / A_d;
+        return Point_T<T>(x_d, y_d);
+    }
+
+    template<typename T>
+    Point_T<T> ne2dp_Numerical(Eigen::Matrix<T, 3, 3> Q, std::vector<T> ds) {
+        int total_iter = 100;
+        int iter = (int)(sqrt(total_iter));
+        array<T, 5> ellipse = ellipse2array(Q);
+
+        T a, b, tx, ty, alpha;
+        tx = ellipse[0];
+        ty = ellipse[1];
+        a = ellipse[2];
+        b = ellipse[3];
+        alpha = ellipse[4];
+        T A_d = T(0);
+        T x_d = T(0);
+        T y_d = T(0);
+
+        T r_step = T(1.0) / T(iter);
+        T t_step = T(2 * M_PI) / T(iter);
+
+        for (int i = 0; i < iter + 1; i++) {
+            for (int j = 0; j < iter + 1; j++) {
+                int scale_i = 2;
+                int scale_j = 2;
+                if (i == 0 || i == iter) scale_i = 1;
+                if (j == 0 || j == iter) scale_j = 1;
+                T r = r_step * T(i);
+                T t = t_step * T(j);
+
+                T x_n = tx + a * r * ceres::cos(alpha) * ceres::cos(t) - b * r * ceres::sin(alpha) * ceres::sin(t);
+                T y_n = ty + a * r * ceres::sin(alpha) * ceres::cos(t) + b * r * ceres::cos(alpha) * ceres::sin(t);
+                T s_n = ceres::pow(x_n, 2) + ceres::pow(y_n, 2);
+                T tmp1 = T(0);
+                T tmp2 = T(0);
+                for (int k = 0; k < max_dim + 1; k++) {
+                    tmp1 += ds[k] * ceres::pow(s_n, k);
+                    tmp2 += (T(2 * k + 1)) * ds[k] * ceres::pow(s_n, k);
+                }
+                T Jdn = tmp1 * tmp2;
+                T Jnrt = a * b * r;
+
+                T x_d_t = tmp1 * x_n;
+                T y_d_t = tmp1 * y_n;
+
+                A_d += Jdn * Jnrt * r_step * t_step * T(scale_i * scale_j) / T(4);
+                x_d += x_d_t * Jdn * Jnrt * r_step * t_step * T(scale_i * scale_j) / T(4);
+                y_d += y_d_t * Jdn * Jnrt * r_step * t_step * T(scale_i * scale_j) / T(4);
+            }
+        }
+        x_d = x_d / A_d;
+        y_d = y_d / A_d;
+        return Point_T<T>(x_d, y_d);
+    }
+
+    template<typename T>
+    Point_T<T> distort_Point(Point_T<T> pn, std::vector<T> ds) {
+        T x, s, y, k;
+        x = pn.x;
+        y = pn.y;
+        s = x * x + y * y;
+        k = T(0);
+        for (int i = 0; i < max_dim + 1; i++) {
+            k += ds[i] * ceres::pow(s, i);
+        }
+        return Point_T<T>(k * x, k * y);
+    }
+
+    template<typename T>
+    Point_T<T> ne2dp(Eigen::Matrix<T, 3, 3> Q, const std::vector<T>& ds) {
+        /*
+        input: ellips in normal plane and distortion parameter
+        output: centor point of region of distorted ellipse
+        */
+
+        std::array<T, 5> ellipse = ellipse2array(Q);
+
+        T a, b, tx, ty, alpha;
+        tx = ellipse[0];
+        ty = ellipse[1];
+        a = ellipse[2];
+        b = ellipse[3];
+        alpha = ellipse[4];
+        T A_d = T(0);
+        T x_d = T(0);
+        T y_d = T(0);
+
+        for (int n = 0; n < 3 * max_dim + 1; n++) {
+            T c_0n = C0n(n, ds);
+            T c_1n = C1n(n, ds); 
+            std::array<T, 3> all_Sn = intSn(n, a, b, tx, ty, alpha);
+            A_d += c_0n * all_Sn[0];
+            x_d += c_1n * all_Sn[1];
+            y_d += c_1n * all_Sn[2];
+        }
+
+        x_d = x_d / A_d;
+        y_d = y_d / A_d;
+        return Point_T<T>(x_d, y_d);
+    }
+
+    template<typename T>
+    Point_T<T> project(T wx, T wy, T r, Params_T<T> intrinsic, Eigen::Matrix<T, 3, 3> E, int mode=0) {
+        Eigen::Matrix<T, 3, 3> Cw;
+
+        Cw <<   T(1.0), T(0.0), -wx,
+                T(0.0), T(1.0), -wy,
+                -wx, -wy, ceres::pow(wx,2) + ceres::pow(wy,2) - ceres::pow(r,2); // ceres::pow
+
+        std::vector<T> ds = {T(1), intrinsic.d[0], intrinsic.d[1], intrinsic.d[2], intrinsic.d[3]};
+
+        Point_T<T> dp(T(0),T(0));
+        if(mode == 0){
+            Eigen::Matrix<T, 3, 3> E_inv=  E.inverse();
+            Eigen::Matrix<T, 3, 3> Qn = E_inv.transpose()*Cw*E_inv;
+            dp = ne2dp(Qn,ds);
+        }
+        else if(mode == 1){
+            Eigen::Matrix<T, 3, 3> E_inv=  E.inverse();
+            Eigen::Matrix<T, 3, 3> Qn = E_inv.transpose()*Cw*E_inv;
+            array<T,5> ellipse_n= ellipse2array(Qn);
+            Point_T<T> pn(ellipse_n[0],ellipse_n[1]);
+            dp = distort_Point(pn,ds);
+        }
+        else if(mode == 2){
+            Eigen::Matrix<T, 3, 1> Pw;
+            Pw << wx, wy, T(1.0);
+            Eigen::Matrix<T, 3, 1> Pn = E*Pw;
+            Point_T<T> pn(Pn[0]/Pn[2],Pn[1]/Pn[2]);
+            dp = distort_Point(pn,ds);
+        }
+        else if(mode == 3){
+            Eigen::Matrix<T, 3, 3> E_inv=  E.inverse();
+            Eigen::Matrix<T, 3, 3> Qn = E_inv.transpose()*Cw*E_inv;
+            dp = ne2dp_Numerical(Qn,ds);
+        }
+        else if(mode == 4){
+            dp = wc2dp_Numerical(Cw,E,ds);
+        }
+        else{
+            throw MomentsTrackerError();
+        }
+
+        T u_e = dp.x*intrinsic.fx+dp.y*intrinsic.skew+intrinsic.cx; 
+        T v_e = dp.y*intrinsic.fy+intrinsic.cy;
+
+        return Point_T<T>(u_e, v_e);
+    }
+
+    template<typename T> 
+    array<T, 5> ellipse2array(Eigen::Matrix<T, 3, 3> Q) {
+        T a = Q(0, 0), b = Q(0, 1), c = Q(1, 1), d = Q(0, 2), e = Q(1, 2), f = Q(2, 2);
+        T x, y, m0, m1, v0, v1;
+        T det_Q = Q.determinant(); 
+        T det_Q33 = a * c - b * b; 
+        T s = a + c;
+        x = (-c * d + b * e) / det_Q33;
+        y = (b * d - a * e) / det_Q33;
+
+        T k = -det_Q / det_Q33;
+        T root = ceres::sqrt(ceres::pow(a - c, T(2)) + T(4) * ceres::pow(b, T(2)));
+        T lamda0 = (s - root) / T(2);
+        T lamda1 = (s + root) / T(2);
+        m0 = ceres::sqrt(k / lamda0);
+        m1 = ceres::sqrt(k / lamda1);
+        
+        if (ceres::abs(b) < T(1e-12)) {
+            v0 = T(0);
+            v1 = T(1);
+        } else {
+            v0 = ((c - a) + root) / T(2);
+            v1 = -b;
+        }
+        T alpha = ceres::atan2(v1, v0);
+
+        array<T, 5> result = {x, y, m0, m1, alpha};
+        return result;
+    }
+
+
+
+
 };
 
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,6 +3,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include <tabulate/table.hpp>
+#include "ceres/ceres.h"
 #include <filesystem>
 #include <iostream>
 
@@ -129,117 +130,139 @@ struct Shape{
 };
 
 
-struct Params{
-    double fx;
-    double fy;
-    double cx;
-    double cy;
-    double skew;
-    double d[4];
-    // double radius;
-    double s_fx;
-    double s_fy;
-    double s_cx;
-    double s_cy;
-    double s_skew;
-    double s_d[4];
-    // double s_radius;
+template<typename T>
+struct Params_T {
+    T fx;
+    T fy;
+    T cx;
+    T cy;
+    T skew;
+    std::array<T, 4> d;
+    
+    T s_fx;
+    T s_fy;
+    T s_cx;
+    T s_cy;
+    T s_skew;
+    std::array<T, 4> s_d;
 
-    Params(double _fx=0, double _fy=0, double _cx=0, double _cy=0, double _skew=0, double _d1=0, double _d2=0, double _d3=0, double _d4=0){
-        fx = _fx;
-        fy = _fy;
-        cx = _cx;
-        cy = _cy;
-        skew = _skew;
+    // Default constructor
+    Params_T(T _fx = T(0), T _fy = T(0), T _cx = T(0), T _cy = T(0), T _skew = T(0),
+           T _d1 = T(0), T _d2 = T(0), T _d3 = T(0), T _d4 = T(0))
+    : fx(_fx), fy(_fy), cx(_cx), cy(_cy), skew(_skew) {
         d[0] = _d1;
         d[1] = _d2;
         d[2] = _d3;
         d[3] = _d4;
-        // radius = _radius;
-        initialize_unc();
+        // initialize_unc();
     }
-    Params(YAML::Node camera_node){
-        fx = camera_node["fx"].as<double>();
-        fy = camera_node["fy"].as<double>();
-        cx = camera_node["cx"].as<double>();
-        cy = camera_node["cy"].as<double>();
-        skew = camera_node["skew"].as<double>();
-        d[0] = camera_node["d1"].as<double>();
-        d[1] = camera_node["d2"].as<double>();
-        d[2] = camera_node["d3"].as<double>();
-        d[3] = camera_node["d4"].as<double>();
-        initialize_unc();
+    
+    // YAML constructor
+    Params_T(YAML::Node camera_node) {
+        fx = static_cast<T>(camera_node["fx"].as<double>());
+        fy = static_cast<T>(camera_node["fy"].as<double>());
+        cx = static_cast<T>(camera_node["cx"].as<double>());
+        cy = static_cast<T>(camera_node["cy"].as<double>());
+        skew = static_cast<T>(camera_node["skew"].as<double>());
+        d[0] = static_cast<T>(camera_node["d1"].as<double>());
+        d[1] = static_cast<T>(camera_node["d2"].as<double>());
+        d[2] = static_cast<T>(camera_node["d3"].as<double>());
+        d[3] = static_cast<T>(camera_node["d4"].as<double>());
+        // initialize_unc();
     }
-    void update_unc(std::array<double,9> params_cov){
-        s_fx = params_cov[0];
-        s_fy = params_cov[1];
-        s_cx = params_cov[2];
-        s_cy = params_cov[3];
-        s_skew = params_cov[4];
-        s_d[0] = params_cov[5];
-        s_d[1] = params_cov[6];
-        s_d[2] = params_cov[7];
-        s_d[3] = params_cov[8];
+
+    void update_unc(const std::array<double, 9>& params_cov) {
+        s_fx = static_cast<T>(params_cov[0]);
+        s_fy = static_cast<T>(params_cov[1]);
+        s_cx = static_cast<T>(params_cov[2]);
+        s_cy = static_cast<T>(params_cov[3]);
+        s_skew = static_cast<T>(params_cov[4]);
+        s_d[0] = static_cast<T>(params_cov[5]);
+        s_d[1] = static_cast<T>(params_cov[6]);
+        s_d[2] = static_cast<T>(params_cov[7]);
+        s_d[3] = static_cast<T>(params_cov[8]);
     }
-    void initialize_unc(){
-        std::array<double,9> params_cov{0,};
+    
+    void initialize_unc() {
+        std::array<T, 9> params_cov;
+        params_cov.fill(T(0));
         update_unc(params_cov);
     }
-    int get_precision(double s){
-        int max_precision =0;
+    
+    int get_precision(T s) {
+        int max_precision = 0;
         int min_precision = -4;
-        for(int i =max_precision; i>=min_precision;i--){
-            double mod= pow(10, i);
-            int v = floor(s/mod);
-            if(v!=0){
+        for (int i = max_precision; i >= min_precision; i--) {
+            T mod = ceres::pow(T(10), T(i));
+            T v = ceres::floor(s / mod);
+            if (v != T(0)) {
                 return -i;
             }
         }
         return 4;
     }
-    std::string sigma3(double x, double s_x){
-        int n = get_precision(s_x);
-        int toralance = 3;
-        return to_stringf(x,n)+"\u00B1"+to_stringf(toralance*s_x,n+1);
+
+    std::string sigma3(T x, T s_x) {
+        if (std::is_same_v<T, double>) { // only double type
+            int n = get_precision(s_x);
+            int toralance = 3;
+            return to_stringf(x, n) + "\u00B1" + to_stringf(T(toralance) * s_x, n + 1);
+        }
+        else return std::string();
     }
-    std::string to_string(){
-        std::string str = "fx\tfy\tcx\tcy\tskew\td1\td2\td3\td4\n"
-        +std::to_string(fx) + "\t"+std::to_string(fy) + "\t"+std::to_string(cx) + "\t"+std::to_string(cy) + "\t"+std::to_string(skew) 
-        + "\t"+std::to_string(d[0]) + "\t"+std::to_string(d[1]) + "\t"+std::to_string(d[2]) + "\t"+std::to_string(d[3]);
+    
+    std::string to_string() {
+        std::string str = "fx\tfy\tcx\tcy\tskew\td1\td2\td3\td4\n";
+        str += std::to_string(static_cast<double>(fx)) + "\t";
+        str += std::to_string(static_cast<double>(fy)) + "\t";
+        str += std::to_string(static_cast<double>(cx)) + "\t";
+        str += std::to_string(static_cast<double>(cy)) + "\t";
+        str += std::to_string(static_cast<double>(skew)) + "\t";
+        str += std::to_string(static_cast<double>(d[0])) + "\t";
+        str += std::to_string(static_cast<double>(d[1])) + "\t";
+        str += std::to_string(static_cast<double>(d[2])) + "\t";
+        str += std::to_string(static_cast<double>(d[3]));
         return str;
     }
-    tabulate::Table to_table(bool only_intrinsic = false,  bool details = false){
+
+    tabulate::Table to_table(bool only_intrinsic = false, bool details = false) {
         tabulate::Table table;
-        int toralance = 2;
-        if(only_intrinsic){
-            table.add_row({"Parameter","fx", "fy", "cx","cy","skew"});
-            table.add_row({"mean", to_stringf(fx, 2), to_stringf(fy, 2), to_stringf(cx, 2),to_stringf(cy, 2),to_stringf(skew, 2)
-            });
-        }
-        else{
-            table.add_row({"Parameter","fx", "fy", "cx","cy","skew","d1","d2","d3","d4"});
-            table.add_row({ "mean",to_stringf(fx, 2), to_stringf(fy, 2), to_stringf(cx, 2), to_stringf(cy, 2),to_stringf(skew, 2),
-            to_stringf(d[0], 3), to_stringf(d[1], 3),to_stringf(d[2], 3),to_stringf(d[3], 4)
-            });
-            if(details){
-                table.add_row({ "2sigma",to_stringf(toralance*s_fx, 3), to_stringf(toralance*s_fy, 3),to_stringf(toralance*s_cx, 3), to_stringf(toralance*s_cy, 3),to_stringf(toralance*s_skew, 3),
-                   to_stringf(toralance*s_d[0], 4), to_stringf(toralance*s_d[1], 4),to_stringf(toralance*s_d[2], 4),to_stringf(toralance*s_d[3], 5)
-                });
-                // table.add_row({ sigma3(fx, s_fx), sigma3(fy, s_fy), sigma3(cx, s_cx),sigma3(cy, s_cy),sigma3(skew, s_skew),
-                // sigma3(d[0],s_d[0]), sigma3(d[1],s_d[1]), sigma3(d[2],s_d[2]), sigma3(d[3],s_d[3]), sigma3(radius,s_radius)});
+        if (std::is_same_v<T, double>) { // only double type
+            int toralance = 2;
+            if (only_intrinsic) {
+                table.add_row({"Parameter", "fx", "fy", "cx", "cy", "skew"});
+                table.add_row({"mean", to_stringf(fx, 2), to_stringf(fy, 2), to_stringf(cx, 2), to_stringf(cy, 2), to_stringf(skew, 2)});
+            } else {
+                table.add_row({"Parameter", "fx", "fy", "cx", "cy", "skew", "d1", "d2", "d3", "d4"});
+                table.add_row({"mean", to_stringf(fx, 2), to_stringf(fy, 2), to_stringf(cx, 2), to_stringf(cy, 2), to_stringf(skew, 2),
+                               to_stringf(d[0], 3), to_stringf(d[1], 3), to_stringf(d[2], 3), to_stringf(d[3], 4)});
+                if (details) {
+                    table.add_row({"2sigma", to_stringf(T(toralance) * s_fx, 3), to_stringf(T(toralance) * s_fy, 3),
+                                   to_stringf(T(toralance) * s_cx, 3), to_stringf(T(toralance) * s_cy, 3), to_stringf(T(toralance) * s_skew, 3),
+                                   to_stringf(T(toralance) * s_d[0], 4), to_stringf(T(toralance) * s_d[1], 4),
+                                   to_stringf(T(toralance) * s_d[2], 4), to_stringf(T(toralance) * s_d[3], 5)});
+                }
             }
         }
-        
-        
         return table;
     }
 };
 
-struct Point{
-    double x;
-    double y;
-    Point(double _x, double _y) : x(_x), y(_y){};
+typedef Params_T<double> Params;
+
+// struct Point{
+//     double x;
+//     double y;
+//     Point(double _x, double _y) : x(_x), y(_y){};
+// };
+
+template<typename T>
+struct Point_T {
+    T x, y;
+    Point_T(T _x, T _y) : x(_x), y(_y) {};
 };
+
+typedef Point_T<double> Point;
 
 static bool endsWith(std::string const &str, std::string const &suffix) {
     if (str.length() < suffix.length()) {

--- a/src/lib_calib/CCalibrator.cpp
+++ b/src/lib_calib/CCalibrator.cpp
@@ -121,9 +121,9 @@ Params Calibrator::batch_optimize(std::vector<int> sample, Params initial_params
     for(int i=0;i<sample.size();i++){
         int index =sample.at(i);
         int num_residual= targets.at(index).size()*2;
-
-        CostFunction* cost_function = new NumericDiffCostFunction<CalibrationFunctor,ceres::CENTRAL, ceres::DYNAMIC,5,4,3,3>(
-            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,projection_mode,use_weight), ceres::TAKE_OWNERSHIP, num_residual
+        // Change to AutoDiffCostFunction
+        CostFunction* cost_function = new AutoDiffCostFunction<CalibrationFunctor, ceres::DYNAMIC, 5,4,3,3>(
+            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,projection_mode,use_weight), num_residual
         );
 
         problem.AddResidualBlock(cost_function, loss_function, fcs, distorsion, Es.at(index).rot.data(),Es.at(index).trans.data() );
@@ -134,7 +134,6 @@ Params Calibrator::batch_optimize(std::vector<int> sample, Params initial_params
         problem.SetParameterBlockConstant(distorsion);
     }
 
-    
     
     // Run the solver!
     Solver::Options options;
@@ -156,13 +155,10 @@ Params Calibrator::batch_optimize(std::vector<int> sample, Params initial_params
     // printf("final error: %f\n",summary.final_cost);
     // std::vector<double*> Problem::EvaluateOptions::parameter_blocks;
     // eval_option.parameter_blocks={};
-
     Solve(options, &problem, &summary);
     normalize_Es();
 
     Params results(fcs[0],fcs[1],fcs[2],fcs[3],fcs[4],distorsion[0],distorsion[1],distorsion[2],distorsion[3]);
-
-    
 
     double cost = 0.0;
     Problem::EvaluateOptions eval_option;
@@ -176,9 +172,9 @@ Params Calibrator::batch_optimize(std::vector<int> sample, Params initial_params
         int index =sample.at(i);
         int num_residual= targets.at(index).size()*2;
         use_weight =false;
-
-        CostFunction* cost_function = new NumericDiffCostFunction<CalibrationFunctor,ceres::CENTRAL, ceres::DYNAMIC, 5,4,3,3>(
-            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,projection_mode,use_weight), ceres::TAKE_OWNERSHIP, num_residual
+        // Change to AutoDiffCostFunction
+        CostFunction* cost_function = new AutoDiffCostFunction<CalibrationFunctor,ceres::DYNAMIC, 5,4,3,3>(
+            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,projection_mode,use_weight), num_residual
         );
         problem2.AddResidualBlock(cost_function, new ceres::TrivialLoss(),fcs, distorsion,Es.at(index).rot.data(),Es.at(index).trans.data() );
 
@@ -500,8 +496,9 @@ void Calibrator::update_Es(Params intrinsic, int mode){
     for(int i=0;i<sample.size();i++){
         int index =sample.at(i);
         int num_residual= targets.at(index).size()*2;
-        CostFunction* cost_function = new NumericDiffCostFunction<CalibrationFunctor,ceres::CENTRAL, ceres::DYNAMIC,5,4,3,3>(
-            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,mode,use_weight), ceres::TAKE_OWNERSHIP, num_residual
+        // Change to AutoDiffCostFunction
+        CostFunction* cost_function = new AutoDiffCostFunction<CalibrationFunctor, ceres::DYNAMIC,5,4,3,3>(
+            new CalibrationFunctor(origin_target,targets[index],original_r,n_d,mode,use_weight), num_residual
         );
         problem.AddResidualBlock(cost_function, loss_function, fcs, distorsion, Es.at(index).rot.data(),Es.at(index).trans.data() );
 

--- a/src/lib_calib/CLieAlgebra.cpp
+++ b/src/lib_calib/CLieAlgebra.cpp
@@ -9,63 +9,6 @@ Eigen::Matrix3d LieAlgebra::skew_symmetric_matrix(const Eigen::Vector3d &v)
     return skew;
 }
 
-Eigen::Vector3d LieAlgebra::to_so3(const Eigen::Matrix3d &R)
-{
-    double trace_R = R.trace();
-    if(trace_R >3 || trace_R <-3) {
-        cout<< R*R.transpose()<<endl;
-        throw LieAlgebraError();
-    }
-    double theta = acos((trace_R - double(1.0)) / double(2.0));
-
-    if (theta == double(0.))
-        return Eigen::Vector3d::Zero();
-
-    Eigen::Matrix3d skew_m = (theta / (double(2.) * sin(theta))) * (R - R.transpose());
-    Eigen::Vector3d skew_v(skew_m(2, 1), skew_m(0, 2), skew_m(1, 0));
-    return skew_v;
-}
-
-Eigen::Vector3d LieAlgebra::normalize_so3(const Eigen::Vector3d &_w)
-{
-    Eigen::Vector3d w = _w;
-    double scale = w.norm()/M_PI;
-    if(scale>1){
-        int share = int(scale);
-        if(share%2 ==0){
-            w = w/scale*(scale-share);
-        }
-        else{
-            w = w/scale*(scale-share-1);
-        }
-    }
-    return w;
-}
-
-Eigen::Matrix3d LieAlgebra::to_SO3(const Eigen::Vector3d & _w)
-{
-    Eigen::Vector3d w = normalize_so3(_w);
-    // Eigen::Vector3d w = _w;
-    double theta = w.norm();
-    if (theta == double(0))
-        return Eigen::Matrix3d::Identity();
-
-    Eigen::Matrix3d w_hat = skew_symmetric_matrix(w);
-    Eigen::Matrix3d mat = Eigen::Matrix3d::Identity() + (sin(theta) / theta) * w_hat + ((1.0 - cos(theta)) / (theta * theta)) * (w_hat * w_hat);
-
-    return mat;
-}
-
-Eigen::Matrix3d LieAlgebra::to_E(se3 se3){
-    
-    Eigen::Matrix3d Rot, E;
-    Rot= LieAlgebra::to_SO3(se3.rot);
-    E.col(0)= Rot.col(0);
-    E.col(1)= Rot.col(1);
-    E.col(2)= se3.trans;
-
-    return E;
-}
 
 Eigen::Matrix4d LieAlgebra::to_SE3(se3 se3){
     Eigen::Matrix4d T;

--- a/src/lib_calib/CMomentsTracker.cpp
+++ b/src/lib_calib/CMomentsTracker.cpp
@@ -45,14 +45,11 @@ void MomentsTracker::init(){
 
 }
 
-double MomentsTracker::nCr(int n, int r){
-    if(n> comb_max || n<r) throw MomentsTrackerError();
-    return (double)(comb_buffer[n][r]);
-}
+
 double MomentsTracker::_M_2i2j(int i, int j){
     // a, b == 1
-    double den= nCr(2*(i+j),i+j)*nCr(i+j,i);
-    double num= nCr(2*(i+j),2*i)*(i+j+1)*pow(2,2*(i+j));
+    double den= nCr<double>(2*(i+j),i+j)*nCr<double>(i+j,i);
+    double num= nCr<double>(2*(i+j),2*i)*(i+j+1)*pow(2,2*(i+j));
     // cout<<den<<num<<endl;
     return den/num;
     
@@ -60,96 +57,6 @@ double MomentsTracker::_M_2i2j(int i, int j){
 double MomentsTracker::M_2i2j(int i, int j){
     if(i> max_n || j>max_n) throw MomentsTrackerError();
     else return moment_buffer[i][j];
-    
-}
-double MomentsTracker::M_2i2j(int i, int j, double a, double b){
-    // return M^{2i2j}
-    return M_2i2j(i,j)*pow(a,2*i)*pow(b,2*j);
-}
-
-
-array<double ,3> MomentsTracker::intSn(int n,double a, double b, double tx, double ty, double alpha){
-    // is validated by wolframAlpha
-    double tx_s = cos(alpha)*tx+sin(alpha)*ty;
-    double ty_s = -sin(alpha)*tx+cos(alpha)*ty;
-    double s0=0,sx=0,sy=0;
-    array<double ,3> results;
-
-    for(int i=0;i<n+1;i++){
-        for(int j=0;j<n-i+1;j++){
-            double M = M_2i2j(i,j,a,b);
-            double m_0 =0;
-            double m_x =0;
-            double m_y =0;
-            for(int k=i;k<n-j+1;k++){
-                m_0+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k));
-                m_x+= nCr(n,k)*nCr(2*k+1,2*i)*nCr(2*(n-k),2*j)*pow(tx_s,2*(k-i)+1)*pow(ty_s,2*(n-j-k));
-                m_y+= nCr(n,k)*nCr(2*k,2*i)*nCr(2*(n-k)+1,2*j)*pow(tx_s,2*(k-i))*pow(ty_s,2*(n-j-k)+1);
-            
-            }
-            
-            s0 += m_0*M;
-            sx += m_x*M;
-            sy += m_y*M;
-            // printf("%d, %d : %e, %e, %e, %e\n",i,j,M,m_0,m_x,m_y);
-        }
-    }
-
-    // support plane to normal plane
-    results[0] = s0;
-    results[1] = cos(alpha)*sx - sin(alpha)*sy;
-    results[2] = sin(alpha)*sx + cos(alpha)*sy;
-    return results;
-
-}
-double MomentsTracker::C0n(int n,vector<double> ds){
-    double result=0;
-    int n_d =max_dim;
-    for(int i=max(0,n-n_d);i<min(n,n_d)+1;i++){
-        result+= (2*i+1)*ds[i]*ds[n-i];
-    }
-    return result;
-}
-double MomentsTracker::C1n(int n,vector<double> ds){
-    double result=0;
-    int n_d =max_dim;
-    for(int i=max(0,n-n_d*2);i<min(n,n_d)+1;i++){
-        double temp =0;
-        for(int j=max(0,n-i-n_d); j<min(n-i,n_d)+1;j++){
-            temp+= ds[j]*ds[n-i-j];
-        }
-        result+= (2*i+1)*ds[i]*temp;
-    }
-    return result;
-}
-
-array<double, 5> MomentsTracker::ellipse2array(Eigen::Matrix3d Q){
-    double a=Q(0,0), b=Q(0,1), c=Q(1,1), d=Q(0,2), e=Q(1,2), f=Q(2,2);
-    double x,y,m0,m1,v0,v1;
-    double det_Q = Q.determinant();
-    double det_Q33 =  a*c-b*b;
-    double s = a+c;
-    x = (-c*d+b*e)/det_Q33;
-    y = (b*d-a*e)/det_Q33;
-
-    double k = - det_Q/det_Q33;
-    double root = sqrt(pow(a-c,2)+4*pow(b,2));
-    double lamda0 = (s-root)/2;
-    double lamda1 = (s+root)/2;
-    m0 = sqrt(k/lamda0);
-    m1 = sqrt(k/lamda1);
-    if (b==0){
-        v0 = 0;
-        v1 = 1;
-    }
-    else{
-        v0 = ((c-a)+root)/2;
-        v1 = -b;
-    }
-    double alpha = atan2(v1,v0);
-
-    array<double, 5> result ={x,y,m0,m1,alpha};
-    return result;
 }
 
 Point MomentsTracker::ne2dp(Eigen::Matrix3d Q, vector<double> ds){
@@ -158,279 +65,24 @@ Point MomentsTracker::ne2dp(Eigen::Matrix3d Q, vector<double> ds){
     output: centor point of region of distorted ellipse
     */
 
-    array<double, 5> ellipse = ellipse2array(Q);
-
-    double a,b,tx,ty,alpha;
-    tx = ellipse[0];
-    ty = ellipse[1];
-    a = ellipse[2];
-    b = ellipse[3];
-    alpha = ellipse[4];
-    double A_d=0; // =Ad/An
-    double x_d=0;
-    double y_d=0;
-
-    for(int n=0;n<3*max_dim+1;n++){
-        double c_0n = C0n(n,ds);
-        double c_1n = C1n(n,ds);
-        array<double,3> all_Sn = intSn(n,a,b,tx,ty,alpha);
-        A_d+= c_0n * all_Sn[0];
-        x_d += c_1n * all_Sn[1];
-        y_d += c_1n * all_Sn[2];
-    }
-
-    x_d = x_d / A_d;
-    y_d = y_d / A_d;
-    return Point(x_d, y_d);
+    return ne2dp<double>(Q, ds);
 }
 
 Point MomentsTracker::distort_Point(Point pn, vector<double> ds){
-    double x, s, y, k;
-    x = pn.x;
-    y = pn.y;
-    s = x*x+y*y;
-    k = 0;
-    for( int i=0;i<max_dim+1;i++){
-        k += ds[i]*pow(s,i);
-    }
-    return Point(k*x, k*y);
+    return distort_Point<double>(pn, ds);
 }
 
 Point MomentsTracker::wc2dp_Numerical(Eigen::Matrix3d Cw, Eigen::Matrix3d H, vector<double> ds, int total_iter){
-    /*
-    input: ellips in normal plane and distortion parameter
-    output: centor point of region of distorted ellipse
-    */
-
-    // int total_iter =pow(5,2);
-    int iter = (int)(sqrt(total_iter));
-    double A_d=0; // =Ad/An
-    double x_d=0;
-    double y_d=0;
-
-    double t_x = -Cw(0,2);
-    double t_y = -Cw(1,2);
-    double R = sqrt(-Cw(2,2)+pow(t_x,2)+pow(t_y,2));
-    double r_step = 1.0/iter;
-    double t_step = 2*M_PI/iter; // t == theta
-
-
-
-    for(int i=0;i<iter+1;i++){
-        for(int j=0;j<iter+1;j++){
-            // int scale_i=2;
-            // int scale_j=2;
-            // if(i==0 || i==iter) scale_i=1;
-            // if(j==0 || j==iter) scale_j=1;
-            // double r = r_step*(i);
-            // double t = t_step*(j);
-            double r = r_step*(i+0.5);
-            double t = t_step*(j+0.5);
-
-            double x_w = t_x + R*r*cos(t);
-            double y_w = t_y + R*r*sin(t);
-            double f = H(0,0)*x_w + H(0,1)*y_w + H(0,2);
-            double g = H(1,0)*x_w + H(1,1)*y_w + H(1,2);
-            double h = H(2,0)*x_w + H(2,1)*y_w + H(2,2);
-            double x_n = f/h;
-            double y_n = g/h;
-
-            double H02 = H(1,0)*H(2,1)-H(1,1)*H(2,0);
-            double H12 = H(0,0)*H(2,1)-H(0,1)*H(2,0);
-            double H22 = H(0,0)*H(1,1)-H(0,1)*H(1,0);
-
-            double Jwrt = R*R*r;
-
-            double Jnw = (H02*f/h -H12*g/h+H22)/pow(h,2);
-
-            // double x_n = tx+a*r*cos(alpha)*cos(t)-b*r*sin(alpha)*sin(t);
-            // double y_n = ty+a*r*sin(alpha)*cos(t)+b*r*cos(alpha)*sin(t);
-            double s_n = pow(x_n,2)+pow(y_n,2);
-            double tmp1=0;
-            double tmp2=0;
-            for(int k=0;k<max_dim+1;k++){
-                tmp1+= ds[k]*pow(s_n,k);
-                tmp2+= (2*k+1)*ds[k]*pow(s_n,k);
-            }
-            double Jdn = tmp1*tmp2;
-            
-
-            double x_d_t = tmp1*x_n;
-            double y_d_t = tmp1*y_n;
-
-            double J = Jdn*Jnw*Jwrt;
-
-            // A_d += J*r_step*t_step*scale_i*scale_j/4;
-            // x_d += x_d_t*J*r_step*t_step*scale_i*scale_j/4;
-            // y_d += y_d_t*J*r_step*t_step*scale_i*scale_j/4;
-            A_d += J*r_step*t_step;
-            x_d += x_d_t*J*r_step*t_step;
-            y_d += y_d_t*J*r_step*t_step;
-        }
-    }
-
-    x_d = x_d/A_d;
-    y_d = y_d/A_d;
-    return Point(x_d, y_d);
+    return wc2dp_Numerical<double>(Cw, H, ds, total_iter);
 }
 
 
 Point MomentsTracker::ne2dp_Numerical(Eigen::Matrix3d Q, vector<double> ds){
-    /*
-    input: ellips in normal plane and distortion parameter
-    output: centor point of region of distorted ellipse
-    */
-
-    int total_iter =100;
-    int iter = (int)(sqrt(total_iter));
-    array<double, 5> ellipse = ellipse2array(Q);
-    
-
-    double a,b,tx,ty,alpha;
-    tx = ellipse[0];
-    ty = ellipse[1];
-    a = ellipse[2];
-    b = ellipse[3];
-    alpha = ellipse[4];
-    double A_d=0; // =Ad/An
-    double x_d=0;
-    double y_d=0;
-
-    double r_step = 1.0/iter;
-    double t_step = 2*M_PI/iter; // t == theta
-
-    // for(int i=0;i<iter+1;i++){
-    //     for(int j=0;j<iter+1;j++){
-    //         int scale_i=4;
-    //         int scale_j=4;
-    //         if(i==0 || i==iter) scale_i=1;
-    //         else if( i%2==0) scale_i=2;
-    //         if(j==0 || j==iter) scale_j=1;
-    //         else if( j%2==0) scale_j=2;
-    //         double r = r_step*(i);
-    //         double t = t_step*(j);
-
-    //         double x_n = tx+a*r*cos(alpha)*cos(t)-b*r*sin(alpha)*sin(t);
-    //         double y_n = ty+a*r*sin(alpha)*cos(t)+b*r*cos(alpha)*sin(t);
-    //         double s_n = pow(x_n,2)+pow(y_n,2);
-    //         double tmp1=0;
-    //         double tmp2=0;
-    //         for(int k=0;k<max_dim+1;k++){
-    //             tmp1+= ds[k]*pow(s_n,k);
-    //             tmp2+= (2*k+1)*ds[k]*pow(s_n,k);
-    //         }
-    //         double Jdn = tmp1*tmp2;
-    //         double Jnrt = a*b*r;
-
-    //         double x_d_t = tmp1*x_n;
-    //         double y_d_t = tmp1*y_n;
-
-    //         A_d += Jdn*Jnrt*r_step*t_step*scale_i*scale_j/9;
-    //         x_d += x_d_t*Jdn*Jnrt*r_step*t_step*scale_i*scale_j/9;
-    //         y_d += y_d_t*Jdn*Jnrt*r_step*t_step*scale_i*scale_j/9;
-    //     }
-    // }
-
-    for(int i=0;i<iter+1;i++){
-        for(int j=0;j<iter+1;j++){
-            int scale_i=2;
-            int scale_j=2;
-            if(i==0 || i==iter) scale_i=1;
-            if(j==0 || j==iter) scale_j=1;
-            double r = r_step*(i);
-            double t = t_step*(j);
-
-            double x_n = tx+a*r*cos(alpha)*cos(t)-b*r*sin(alpha)*sin(t);
-            double y_n = ty+a*r*sin(alpha)*cos(t)+b*r*cos(alpha)*sin(t);
-            double s_n = pow(x_n,2)+pow(y_n,2);
-            double tmp1=0;
-            double tmp2=0;
-            for(int k=0;k<max_dim+1;k++){
-                tmp1+= ds[k]*pow(s_n,k);
-                tmp2+= (2*k+1)*ds[k]*pow(s_n,k);
-            }
-            double Jdn = tmp1*tmp2;
-            double Jnrt = a*b*r;
-
-            double x_d_t = tmp1*x_n;
-            double y_d_t = tmp1*y_n;
-
-            A_d += Jdn*Jnrt*r_step*t_step*scale_i*scale_j/4;
-            x_d += x_d_t*Jdn*Jnrt*r_step*t_step*scale_i*scale_j/4;
-            y_d += y_d_t*Jdn*Jnrt*r_step*t_step*scale_i*scale_j/4;
-        }
-    }
-    // for(int i=0;i<iter;i++){
-    //     for(int j=0;j<iter;j++){
-    //         double r = r_step*(i+0.5);
-    //         double t = t_step*(j+0.5);
-
-    //         double x_n = tx+a*r*cos(alpha)*cos(t)-b*r*sin(alpha)*sin(t);
-    //         double y_n = ty+a*r*sin(alpha)*cos(t)+b*r*cos(alpha)*sin(t);
-    //         double s_n = pow(x_n,2)+pow(y_n,2);
-    //         double tmp1=0;
-    //         double tmp2=0;
-    //         for(int k=0;k<max_dim+1;k++){
-    //             tmp1+= ds[k]*pow(s_n,k);
-    //             tmp2+= (2*k+1)*ds[k]*pow(s_n,k);
-    //         }
-    //         double Jdn = tmp1*tmp2;
-    //         double Jnrt = a*b*r;
-
-    //         double x_d_t = tmp1*x_n;
-    //         double y_d_t = tmp1*y_n;
-
-    //         A_d += Jdn*Jnrt*r_step*t_step;
-    //         x_d += x_d_t*Jdn*Jnrt*r_step*t_step;
-    //         y_d += y_d_t*Jdn*Jnrt*r_step*t_step;
-    //     }
-    // }
-    x_d = x_d/A_d;
-    y_d = y_d/A_d;
-    return Point(x_d, y_d);
+    return ne2dp_Numerical<double>(Q, ds);
 }
 
 
-Point MomentsTracker::project(double wx, double wy, double r,Params intrinsic, Eigen::Matrix3d E, int mode){
-    Eigen::Matrix3d Cw;
-    Cw <<   1.0, 0.0, -wx,
-            0.0, 1.0, -wy,
-            -wx, -wy, pow(wx,2)+pow(wy,2)-pow(r,2);
+Point MomentsTracker::project(double wx, double wy, double r, Params intrinsic, Eigen::Matrix3d E, int mode) {
+    return project<double>(wx, wy, r, intrinsic, E, mode);
 
-    vector<double> ds = {1, intrinsic.d[0], intrinsic.d[1],intrinsic.d[2],intrinsic.d[3]};
-    Point dp(0,0);
-    if(mode ==0){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        dp = ne2dp(Qn,ds);
-    }
-    else if(mode == 1){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        array<double,5> ellipse_n= ellipse2array(Qn);
-        Point pn(ellipse_n[0],ellipse_n[1]);
-        dp = distort_Point(pn,ds);
-    }
-    else if(mode == 2){
-        Eigen::Vector3d Pw{wx,wy,1};
-        Eigen::Vector3d Pn = E*Pw;
-        Point pn(Pn[0]/Pn[2],Pn[1]/Pn[2]);
-        dp = distort_Point(pn,ds);
-    }
-    else if(mode == 3){
-        Eigen::Matrix3d E_inv=  E.inverse();
-        Eigen::Matrix3d Qn = E_inv.transpose()*Cw*E_inv;
-        dp = ne2dp_Numerical(Qn,ds);
-    }
-    else if(mode == 4){
-        dp = wc2dp_Numerical(Cw,E,ds);
-    }
-    else{
-        throw MomentsTrackerError();
-    }
-
-    double u_e = dp.x*intrinsic.fx+dp.y*intrinsic.skew+intrinsic.cx; 
-    double v_e = dp.y*intrinsic.fy+intrinsic.cy;
-
-    return Point(u_e, v_e);
 }


### PR DESCRIPTION
Switched NumericalDiffCostFunction to AutoDiffCostFunction in optimization functions.

This required templating of core components:
* MomentTracker, Calibrator, LieAlgebra
* Structures: Params_T, Point_T,`so3_T, se3_T

Tested and confirmed working with mono.out and stereo.out on sample_imgs.